### PR TITLE
Wire ComfyUI unified /api/jobs and targeted interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,10 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | Tool | Description |
 |------|-------------|
 | `comfyui_get_queue` | Get current execution queue state. |
-| `comfyui_get_job` | Check status of a job by prompt_id. |
+| `comfyui_list_jobs` | List jobs across queue + history with status filter, sorting, and pagination. |
+| `comfyui_get_job` | Look up a single job (queued/running/finished) by prompt_id. |
 | `comfyui_cancel_job` | Cancel a running or queued job. |
-| `comfyui_interrupt` | Interrupt the currently executing workflow. |
+| `comfyui_interrupt` | Interrupt the running workflow (global, or targeted via optional prompt_id). |
 | `comfyui_get_queue_status` | Get detailed queue status including running and pending prompts. |
 | `comfyui_clear_queue` | Clear pending and/or running items from the queue. |
 | `comfyui_get_progress` | Get execution progress for a workflow by prompt_id. Returns status, queue position, and outputs. |

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -220,8 +220,18 @@ class ComfyUIClient:
         r = await self._request("get", "/api/jobs", params=params)
         return r.json()
 
-    async def interrupt(self) -> None:
-        await self._request("post", "/interrupt")
+    async def interrupt(self, prompt_id: str | None = None) -> None:
+        """POST /interrupt — global interrupt, or targeted if prompt_id is given.
+
+        Without prompt_id, interrupts whatever is currently executing.
+        With prompt_id, ComfyUI only interrupts if that prompt is the running one;
+        otherwise the call is a no-op (server returns 200 either way).
+        """
+        if prompt_id is not None:
+            _validate_prompt_id(prompt_id)
+            await self._request("post", "/interrupt", json={"prompt_id": prompt_id})
+        else:
+            await self._request("post", "/interrupt")
 
     async def delete_queue_item(self, prompt_id: str) -> None:
         _validate_prompt_id(prompt_id)

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -166,6 +166,12 @@ class ComfyUIClient:
         r = await self._request("get", f"/history/{prompt_id}")
         return r.json()
 
+    async def get_job(self, job_id: str) -> dict:
+        """GET /api/jobs/{job_id} — unified job lookup across queue + history."""
+        _validate_prompt_id(job_id)
+        r = await self._request("get", f"/api/jobs/{job_id}")
+        return r.json()
+
     async def interrupt(self) -> None:
         await self._request("post", "/interrupt")
 

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -16,6 +16,9 @@ _IDEMPOTENT_HTTP_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE"})
 _RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 _SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+_VALID_JOB_STATUSES = frozenset({"pending", "in_progress", "completed", "failed"})
+_VALID_JOB_SORT_BY = frozenset({"created_at", "execution_duration"})
+_VALID_JOB_SORT_ORDER = frozenset({"asc", "desc"})
 
 
 def _validate_prompt_id(prompt_id: str) -> str:
@@ -170,6 +173,51 @@ class ComfyUIClient:
         """GET /api/jobs/{job_id} — unified job lookup across queue + history."""
         _validate_prompt_id(job_id)
         r = await self._request("get", f"/api/jobs/{job_id}")
+        return r.json()
+
+    async def get_jobs(
+        self,
+        *,
+        status: list[str] | None = None,
+        workflow_id: str | None = None,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """GET /api/jobs — unified, paginated, filterable job list."""
+        if status is not None:
+            invalid = [s for s in status if s not in _VALID_JOB_STATUSES]
+            if invalid:
+                raise ValueError(
+                    f"Invalid status value(s): {invalid}. Valid: {sorted(_VALID_JOB_STATUSES)}"
+                )
+        if sort_by not in _VALID_JOB_SORT_BY:
+            raise ValueError(
+                f"sort_by must be one of {sorted(_VALID_JOB_SORT_BY)}, got {sort_by!r}"
+            )
+        if sort_order not in _VALID_JOB_SORT_ORDER:
+            raise ValueError(
+                f"sort_order must be one of {sorted(_VALID_JOB_SORT_ORDER)}, got {sort_order!r}"
+            )
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+
+        params: dict[str, str] = {
+            "sort_by": sort_by,
+            "sort_order": sort_order,
+            "offset": str(offset),
+        }
+        if status:
+            params["status"] = ",".join(status)
+        if workflow_id:
+            params["workflow_id"] = workflow_id
+        if limit is not None:
+            params["limit"] = str(limit)
+
+        r = await self._request("get", "/api/jobs", params=params)
         return r.json()
 
     async def interrupt(self) -> None:

--- a/src/comfyui_mcp/tools/jobs.py
+++ b/src/comfyui_mcp/tools/jobs.py
@@ -51,11 +51,16 @@ def register_job_tools(
         )
     )
     async def comfyui_get_job(prompt_id: str) -> dict[str, Any]:
-        """Check the status of a specific job by its prompt_id."""
+        """Look up a single job by prompt_id across queue + history.
+
+        Returns the unified job object: status (pending/in_progress/completed/failed),
+        timing, outputs, etc. Use this to check on a job that may be queued, running,
+        or already finished.
+        """
         rl = read_limiter if read_limiter is not None else limiter
         rl.check("get_job")
         await audit.async_log(tool="get_job", action="called", extra={"prompt_id": prompt_id})
-        return await client.get_history_item(prompt_id)
+        return await client.get_job(prompt_id)
 
     tool_fns["comfyui_get_job"] = comfyui_get_job
 

--- a/src/comfyui_mcp/tools/jobs.py
+++ b/src/comfyui_mcp/tools/jobs.py
@@ -158,12 +158,20 @@ def register_job_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_interrupt() -> str:
-        """Interrupt the currently executing workflow."""
+    async def comfyui_interrupt(prompt_id: str | None = None) -> str:
+        """Interrupt the currently executing workflow.
+
+        Without prompt_id: global interrupt — stops whatever is running now.
+        With prompt_id: targeted — only interrupts if that prompt is the
+        running one. ComfyUI silently no-ops if prompt_id is queued but
+        not yet running.
+        """
         limiter.check("interrupt")
-        await audit.async_log(tool="interrupt", action="called")
-        await client.interrupt()
-        return "Interrupted current execution"
+        await audit.async_log(tool="interrupt", action="called", extra={"prompt_id": prompt_id})
+        await client.interrupt(prompt_id=prompt_id)
+        if prompt_id is None:
+            return "Interrupted current execution (global)"
+        return f"Requested interrupt for prompt {prompt_id} (no-op if not running)"
 
     tool_fns["comfyui_interrupt"] = comfyui_interrupt
 

--- a/src/comfyui_mcp/tools/jobs.py
+++ b/src/comfyui_mcp/tools/jobs.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
@@ -63,6 +64,74 @@ def register_job_tools(
         return await client.get_job(prompt_id)
 
     tool_fns["comfyui_get_job"] = comfyui_get_job
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )
+    async def comfyui_list_jobs(
+        status: Annotated[
+            list[Literal["pending", "in_progress", "completed", "failed"]] | None,
+            Field(
+                default=None,
+                description="Filter by job status (any combination).",
+            ),
+        ] = None,
+        workflow_id: Annotated[
+            str | None,
+            Field(default=None, description="Filter by workflow ID set in extra_data."),
+        ] = None,
+        sort_by: Annotated[
+            Literal["created_at", "execution_duration"],
+            Field(default="created_at", description="Sort field."),
+        ] = "created_at",
+        sort_order: Annotated[
+            Literal["asc", "desc"],
+            Field(default="desc", description="Sort direction."),
+        ] = "desc",
+        limit: Annotated[
+            int | None,
+            Field(default=None, ge=1, le=1000, description="Max jobs to return."),
+        ] = None,
+        offset: Annotated[
+            int,
+            Field(default=0, ge=0, description="Jobs to skip for pagination."),
+        ] = 0,
+    ) -> dict[str, Any]:
+        """List jobs across queue and history with filtering, sorting, and pagination.
+
+        Returns {"jobs": [...], "pagination": {"offset", "limit", "total", "has_more"}}.
+        Each job includes prompt_id, status (pending/in_progress/completed/failed),
+        timing, and outputs (when completed).
+        """
+        rl = read_limiter if read_limiter is not None else limiter
+        rl.check("list_jobs")
+        await audit.async_log(
+            tool="list_jobs",
+            action="called",
+            extra={
+                "status": status,
+                "workflow_id": workflow_id,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        return await client.get_jobs(
+            status=list(status) if status is not None else None,
+            workflow_id=workflow_id,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            limit=limit,
+            offset=offset,
+        )
+
+    tool_fns["comfyui_list_jobs"] = comfyui_list_jobs
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/src/comfyui_mcp/tools/jobs.py
+++ b/src/comfyui_mcp/tools/jobs.py
@@ -54,9 +54,15 @@ def register_job_tools(
     async def comfyui_get_job(prompt_id: str) -> dict[str, Any]:
         """Look up a single job by prompt_id across queue + history.
 
-        Returns the unified job object: status (pending/in_progress/completed/failed),
-        timing, outputs, etc. Use this to check on a job that may be queued, running,
-        or already finished.
+        Returns a flat unified job object with top-level keys: prompt_id, status
+        (pending/in_progress/completed/failed), timing fields (created_at,
+        started_at, completed_at, execution_duration), outputs (when completed),
+        and error (when failed). Use this to check on a job that may be queued,
+        running, or already finished.
+
+        Note: this replaces the previous /history/{prompt_id} envelope shape
+        (`{prompt_id: {...}}`); callers should index fields directly on the
+        returned object.
         """
         rl = read_limiter if read_limiter is not None else limiter
         rl.check("get_job")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -155,6 +155,31 @@ class TestComfyUIClient:
         await client.interrupt()
 
     @respx.mock
+    async def test_interrupt_with_prompt_id_sends_body(self, client):
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        route = respx.post("http://test-comfyui:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        await client.interrupt(prompt_id=prompt_id)
+        request = route.calls.last.request
+        body = json.loads(request.content)
+        assert body == {"prompt_id": prompt_id}
+
+    @respx.mock
+    async def test_interrupt_without_prompt_id_sends_no_body(self, client):
+        route = respx.post("http://test-comfyui:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        await client.interrupt()
+        request = route.calls.last.request
+        # Either no body or empty body — definitely no prompt_id
+        assert request.content in (b"", b"{}", None)
+
+    async def test_interrupt_rejects_non_uuid_prompt_id(self, client):
+        with pytest.raises(ValueError, match="Invalid prompt_id"):
+            await client.interrupt(prompt_id="not-a-uuid")
+
+    @respx.mock
     async def test_upload_image(self, client):
         respx.post("http://test-comfyui:8188/upload/image").mock(
             return_value=httpx.Response(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,6 +77,69 @@ class TestComfyUIClient:
             await client.get_job("not-a-uuid")
 
     @respx.mock
+    async def test_get_jobs_no_params(self, client):
+        respx.get("http://test-comfyui:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [],
+                    "pagination": {"offset": 0, "limit": None, "total": 0, "has_more": False},
+                },
+            )
+        )
+        result = await client.get_jobs()
+        assert "jobs" in result
+        assert "pagination" in result
+
+    @respx.mock
+    async def test_get_jobs_passes_filters(self, client):
+        route = respx.get("http://test-comfyui:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [],
+                    "pagination": {"offset": 5, "limit": 10, "total": 0, "has_more": False},
+                },
+            )
+        )
+        await client.get_jobs(
+            status=["pending", "in_progress"],
+            workflow_id="wf-123",
+            sort_by="execution_duration",
+            sort_order="asc",
+            limit=10,
+            offset=5,
+        )
+        request = route.calls.last.request
+        params = dict(request.url.params.multi_items())
+        assert params["status"] == "pending,in_progress"
+        assert params["workflow_id"] == "wf-123"
+        assert params["sort_by"] == "execution_duration"
+        assert params["sort_order"] == "asc"
+        assert params["limit"] == "10"
+        assert params["offset"] == "5"
+
+    async def test_get_jobs_rejects_invalid_status(self, client):
+        with pytest.raises(ValueError, match="Invalid status"):
+            await client.get_jobs(status=["bogus"])
+
+    async def test_get_jobs_rejects_invalid_sort_by(self, client):
+        with pytest.raises(ValueError, match="sort_by"):
+            await client.get_jobs(sort_by="random")
+
+    async def test_get_jobs_rejects_invalid_sort_order(self, client):
+        with pytest.raises(ValueError, match="sort_order"):
+            await client.get_jobs(sort_order="sideways")
+
+    async def test_get_jobs_rejects_negative_limit(self, client):
+        with pytest.raises(ValueError, match="limit"):
+            await client.get_jobs(limit=0)
+
+    async def test_get_jobs_rejects_negative_offset(self, client):
+        with pytest.raises(ValueError, match="offset"):
+            await client.get_jobs(offset=-1)
+
+    @respx.mock
     async def test_get_object_info(self, client):
         respx.get("http://test-comfyui:8188/object_info").mock(
             return_value=httpx.Response(200, json={"KSampler": {"input": {}}})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,6 +56,27 @@ class TestComfyUIClient:
         assert "abc" in result
 
     @respx.mock
+    async def test_get_job_returns_job_object(self, client):
+        job_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        respx.get(f"http://test-comfyui:8188/api/jobs/{job_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "prompt_id": job_id,
+                    "status": "in_progress",
+                    "outputs": {},
+                },
+            )
+        )
+        result = await client.get_job(job_id)
+        assert result["prompt_id"] == job_id
+        assert result["status"] == "in_progress"
+
+    async def test_get_job_rejects_non_uuid(self, client):
+        with pytest.raises(ValueError, match="Invalid prompt_id"):
+            await client.get_job("not-a-uuid")
+
+    @respx.mock
     async def test_get_object_info(self, client):
         respx.get("http://test-comfyui:8188/object_info").mock(
             return_value=httpx.Response(200, json={"KSampler": {"input": {}}})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,9 +131,11 @@ class TestComfyUIClient:
         with pytest.raises(ValueError, match="sort_order"):
             await client.get_jobs(sort_order="sideways")
 
-    async def test_get_jobs_rejects_negative_limit(self, client):
+    async def test_get_jobs_rejects_non_positive_limit(self, client):
         with pytest.raises(ValueError, match="limit"):
             await client.get_jobs(limit=0)
+        with pytest.raises(ValueError, match="limit"):
+            await client.get_jobs(limit=-1)
 
     async def test_get_jobs_rejects_negative_offset(self, client):
         with pytest.raises(ValueError, match="offset"):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -98,23 +98,23 @@ class TestImageGenerationFlow:
                 200, json={"prompt_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
             )
         )
-        respx.get("http://mock-comfyui:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
+        respx.get("http://mock-comfyui:8188/api/jobs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {
-                        "outputs": {
-                            "9": {
-                                "images": [
-                                    {
-                                        "filename": "comfyui-mcp_00001_.png",
-                                        "subfolder": "",
-                                        "type": "output",
-                                    }
-                                ]
-                            }
+                    "prompt_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "status": "completed",
+                    "outputs": {
+                        "9": {
+                            "images": [
+                                {
+                                    "filename": "comfyui-mcp_00001_.png",
+                                    "subfolder": "",
+                                    "type": "output",
+                                }
+                            ]
                         }
-                    }
+                    },
                 },
             )
         )
@@ -131,7 +131,8 @@ class TestImageGenerationFlow:
         job = await integration_stack["comfyui_get_job"](
             prompt_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         )
-        assert "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" in job
+        assert job["prompt_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert job["status"] == "completed"
 
     @respx.mock
     async def test_run_workflow_with_dangerous_node_in_audit_mode(self, integration_stack):

--- a/tests/test_security_invariants.py
+++ b/tests/test_security_invariants.py
@@ -13,6 +13,7 @@ closure cannot call it, transitively or otherwise.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from collections.abc import Iterator
 from typing import Any
@@ -76,7 +77,7 @@ WORKFLOW_SUBMITTING_TOOLS: frozenset[str] = frozenset(
 
 
 @pytest.fixture
-def all_tools(tmp_path: Any) -> dict[str, Any]:
+def all_tools(tmp_path: Any) -> Iterator[dict[str, Any]]:
     """Build every tool from every register_*_tools() with real wiring.
 
     Mirrors server.py:_build_server() but skips FastMCP transport setup.
@@ -152,7 +153,13 @@ def all_tools(tmp_path: Any) -> dict[str, Any]:
             node_auditor=node_auditor,
         )
     )
-    return tools
+    try:
+        yield tools
+    finally:
+        # search_http is captured in closures but never invoked here
+        # (we only inspect closures). Close it anyway to avoid unclosed-client
+        # ResourceWarnings during the test run.
+        asyncio.run(search_http.aclose())
 
 
 def _closure_values(fn: Any) -> Iterator[Any]:

--- a/tests/test_security_invariants.py
+++ b/tests/test_security_invariants.py
@@ -1,0 +1,229 @@
+"""Static invariants for CLAUDE.md security rules 2-5.
+
+Verifies every registered MCP tool has access to the required security
+primitives via its closure. This converts the per-call conventions for rate
+limiting, audit logging, path sanitization, and workflow inspection from
+"enforced by checklist" to "structurally enforced at registration time".
+
+Approach: each tool function returned by ``register_*_tools()`` is a closure
+over its enclosing scope. ``inspect.getclosurevars(fn).nonlocals`` returns
+exactly those captured names. A tool that lacks the security primitive in its
+closure cannot call it, transitively or otherwise.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.config import ModelSearchSettings
+from comfyui_mcp.model_manager import ModelManagerDetector
+from comfyui_mcp.node_manager import ComfyUIManagerDetector
+from comfyui_mcp.progress import WebSocketProgress
+from comfyui_mcp.security.download_validator import DownloadValidator
+from comfyui_mcp.security.inspector import WorkflowInspector
+from comfyui_mcp.security.model_checker import ModelChecker
+from comfyui_mcp.security.node_auditor import NodeAuditor
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+from comfyui_mcp.tools.discovery import register_discovery_tools
+from comfyui_mcp.tools.files import register_file_tools
+from comfyui_mcp.tools.generation import register_generation_tools
+from comfyui_mcp.tools.history import register_history_tools
+from comfyui_mcp.tools.jobs import register_job_tools
+from comfyui_mcp.tools.models import register_model_tools
+from comfyui_mcp.tools.nodes import register_node_tools
+from comfyui_mcp.tools.workflow import register_workflow_tools
+
+# Tools that take a filename, subfolder, folder, or template-param input that
+# resolves to a path-like value. Adding a tool here without wiring sanitizer
+# into its closure will fail test_file_handling_tools_have_sanitizer.
+FILE_HANDLING_TOOLS: frozenset[str] = frozenset(
+    {
+        "comfyui_list_models",
+        "comfyui_get_model_metadata",
+        "comfyui_upload_image",
+        "comfyui_get_image",
+        "comfyui_upload_mask",
+        "comfyui_get_workflow_from_image",
+        "comfyui_transform_image",
+        "comfyui_inpaint_image",
+        "comfyui_upscale_image",
+        "comfyui_download_model",
+        "comfyui_create_workflow",
+    }
+)
+
+# Tools that submit a workflow via client.post_prompt() — must go through the
+# WorkflowInspector per CLAUDE.md rule 5.
+WORKFLOW_SUBMITTING_TOOLS: frozenset[str] = frozenset(
+    {
+        "comfyui_run_workflow",
+        "comfyui_run_workflow_stream",
+        "comfyui_generate_image",
+        "comfyui_transform_image",
+        "comfyui_inpaint_image",
+        "comfyui_upscale_image",
+    }
+)
+
+
+@pytest.fixture
+def all_tools(tmp_path: Any) -> dict[str, Any]:
+    """Build every tool from every register_*_tools() with real wiring.
+
+    Mirrors server.py:_build_server() but skips FastMCP transport setup.
+    No HTTP traffic occurs — closures are inspected, not invoked.
+    """
+    client = ComfyUIClient(base_url="http://mock-comfyui:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    inspector = WorkflowInspector(mode="audit", dangerous_nodes=[], allowed_nodes=[])
+    sanitizer = PathSanitizer(allowed_extensions=[".png", ".jpg", ".json"])
+    model_sanitizer = PathSanitizer(allowed_extensions=[".safetensors", ".gguf"])
+    node_auditor = NodeAuditor()
+    model_checker = ModelChecker()
+    download_validator = DownloadValidator(
+        allowed_domains=["huggingface.co"],
+        allowed_extensions=[".safetensors", ".gguf"],
+    )
+    detector = ModelManagerDetector(client)
+    node_manager = ComfyUIManagerDetector(client)
+    progress = WebSocketProgress(client)
+    search_http = httpx.AsyncClient()
+    model_search_settings = ModelSearchSettings()
+
+    rl_workflow = RateLimiter(max_per_minute=10)
+    rl_generation = RateLimiter(max_per_minute=10)
+    rl_file = RateLimiter(max_per_minute=30)
+    rl_read = RateLimiter(max_per_minute=60)
+
+    mcp = FastMCP("invariants-test")
+
+    tools: dict[str, Any] = {}
+    tools.update(register_discovery_tools(mcp, client, audit, rl_read, sanitizer, node_auditor))
+    tools.update(register_history_tools(mcp, client, audit, rl_read))
+    tools.update(
+        register_job_tools(mcp, client, audit, rl_workflow, read_limiter=rl_read, progress=progress)
+    )
+    tools.update(register_file_tools(mcp, client, audit, rl_file, sanitizer))
+    tools.update(
+        register_generation_tools(
+            mcp,
+            client,
+            audit,
+            rl_generation,
+            inspector,
+            read_limiter=rl_read,
+            progress=progress,
+            model_checker=model_checker,
+            sanitizer=sanitizer,
+        )
+    )
+    tools.update(register_workflow_tools(mcp, client, audit, rl_read, inspector, sanitizer))
+    tools.update(
+        register_model_tools(
+            mcp=mcp,
+            client=client,
+            audit=audit,
+            read_limiter=rl_read,
+            file_limiter=rl_file,
+            sanitizer=model_sanitizer,
+            detector=detector,
+            validator=download_validator,
+            search_settings=model_search_settings,
+            search_http=search_http,
+        )
+    )
+    tools.update(
+        register_node_tools(
+            mcp=mcp,
+            client=client,
+            audit=audit,
+            wf_limiter=rl_workflow,
+            read_limiter=rl_read,
+            node_manager=node_manager,
+            node_auditor=node_auditor,
+        )
+    )
+    return tools
+
+
+def _closure_values(fn: Any) -> Iterator[Any]:
+    """Yield every nonlocal value captured by ``fn``'s closure."""
+    yield from inspect.getclosurevars(fn).nonlocals.values()
+
+
+def _has_instance_of(fn: Any, cls: type) -> bool:
+    """True if any closure variable of ``fn`` is an instance of ``cls``."""
+    return any(isinstance(v, cls) for v in _closure_values(fn))
+
+
+class TestRateLimiterInvariant:
+    """CLAUDE.md rule 3: All tools must go through the rate limiter."""
+
+    def test_every_tool_has_a_rate_limiter_in_closure(self, all_tools: dict[str, Any]) -> None:
+        missing = [name for name, fn in all_tools.items() if not _has_instance_of(fn, RateLimiter)]
+        assert not missing, (
+            f"{len(missing)} tool(s) have no RateLimiter in closure — "
+            f"cannot enforce CLAUDE.md rule 3: {sorted(missing)}"
+        )
+
+
+class TestAuditInvariant:
+    """CLAUDE.md rule 4: All tools must audit log."""
+
+    def test_every_tool_has_an_audit_logger_in_closure(self, all_tools: dict[str, Any]) -> None:
+        missing = [name for name, fn in all_tools.items() if not _has_instance_of(fn, AuditLogger)]
+        assert not missing, (
+            f"{len(missing)} tool(s) have no AuditLogger in closure — "
+            f"cannot enforce CLAUDE.md rule 4: {sorted(missing)}"
+        )
+
+
+class TestSanitizerInvariant:
+    """CLAUDE.md rule 2: All file-handling tools must use PathSanitizer."""
+
+    def test_file_handling_tools_have_sanitizer_in_closure(self, all_tools: dict[str, Any]) -> None:
+        unknown = FILE_HANDLING_TOOLS - all_tools.keys()
+        assert not unknown, (
+            f"FILE_HANDLING_TOOLS lists tool(s) that no longer exist: {sorted(unknown)}. "
+            "Update the allowlist."
+        )
+        missing = [
+            name
+            for name in FILE_HANDLING_TOOLS
+            if not _has_instance_of(all_tools[name], PathSanitizer)
+        ]
+        assert not missing, (
+            f"{len(missing)} file-handling tool(s) have no PathSanitizer in closure — "
+            f"cannot enforce CLAUDE.md rule 2: {sorted(missing)}"
+        )
+
+
+class TestInspectorInvariant:
+    """CLAUDE.md rule 5: Workflow execution must go through the inspector."""
+
+    def test_workflow_submitting_tools_have_inspector_in_closure(
+        self, all_tools: dict[str, Any]
+    ) -> None:
+        unknown = WORKFLOW_SUBMITTING_TOOLS - all_tools.keys()
+        assert not unknown, (
+            f"WORKFLOW_SUBMITTING_TOOLS lists tool(s) that no longer exist: {sorted(unknown)}. "
+            "Update the allowlist."
+        )
+        missing = [
+            name
+            for name in WORKFLOW_SUBMITTING_TOOLS
+            if not _has_instance_of(all_tools[name], WorkflowInspector)
+        ]
+        assert not missing, (
+            f"{len(missing)} workflow-submitting tool(s) have no WorkflowInspector in closure — "
+            f"cannot enforce CLAUDE.md rule 5: {sorted(missing)}"
+        )

--- a/tests/test_tools_jobs.py
+++ b/tests/test_tools_jobs.py
@@ -89,6 +89,54 @@ class TestGetJob:
         assert result["status"] == "in_progress"
 
 
+class TestListJobs:
+    @respx.mock
+    async def test_list_jobs_default(self, components):
+        client, audit, limiter = components
+        respx.get("http://test:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [{"prompt_id": "abc", "status": "completed"}],
+                    "pagination": {"offset": 0, "limit": None, "total": 1, "has_more": False},
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_list_jobs"]()
+        assert "jobs" in result
+        assert "pagination" in result
+        assert result["jobs"][0]["status"] == "completed"
+
+    @respx.mock
+    async def test_list_jobs_passes_filters(self, components):
+        client, audit, limiter = components
+        route = respx.get("http://test:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [],
+                    "pagination": {"offset": 0, "limit": 5, "total": 0, "has_more": False},
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        await tools["comfyui_list_jobs"](
+            status=["pending", "in_progress"],
+            sort_by="execution_duration",
+            sort_order="asc",
+            limit=5,
+            offset=0,
+        )
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["status"] == "pending,in_progress"
+        assert params["sort_by"] == "execution_duration"
+        assert params["sort_order"] == "asc"
+        assert params["limit"] == "5"
+
+
 class TestGetQueueStatus:
     @respx.mock
     async def test_get_queue_status_returns_exec_info(self, components):

--- a/tests/test_tools_jobs.py
+++ b/tests/test_tools_jobs.py
@@ -69,18 +69,24 @@ class TestInterrupt:
 
 class TestGetJob:
     @respx.mock
-    async def test_get_job_returns_history_item(self, components):
+    async def test_get_job_returns_unified_job_object(self, components):
         client, audit, limiter = components
-        respx.get("http://test:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
             return_value=httpx.Response(
                 200,
-                json={"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {"outputs": {"9": {"images": []}}}},
+                json={
+                    "prompt_id": prompt_id,
+                    "status": "in_progress",
+                    "outputs": {},
+                },
             )
         )
         mcp = FastMCP("test")
         tools = register_job_tools(mcp, client, audit, limiter)
-        result = await tools["comfyui_get_job"](prompt_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-        assert "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" in result
+        result = await tools["comfyui_get_job"](prompt_id=prompt_id)
+        assert result["prompt_id"] == prompt_id
+        assert result["status"] == "in_progress"
 
 
 class TestGetQueueStatus:

--- a/tests/test_tools_jobs.py
+++ b/tests/test_tools_jobs.py
@@ -56,15 +56,36 @@ class TestCancelJob:
 
 class TestInterrupt:
     @respx.mock
-    async def test_interrupt_posts(self, components):
+    async def test_interrupt_global(self, components):
         client, audit, limiter = components
         route = respx.post("http://test:8188/interrupt").mock(
             return_value=httpx.Response(200, json={})
         )
         mcp = FastMCP("test")
         tools = register_job_tools(mcp, client, audit, limiter)
-        await tools["comfyui_interrupt"]()
+        result = await tools["comfyui_interrupt"]()
         assert route.called
+        body = route.calls.last.request.content
+        # No prompt_id sent → no body, or empty
+        assert body in (b"", b"{}", None)
+        assert "current" in result.lower() or "global" in result.lower()
+
+    @respx.mock
+    async def test_interrupt_targeted(self, components):
+        import json as _json
+
+        client, audit, limiter = components
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        route = respx.post("http://test:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_interrupt"](prompt_id=prompt_id)
+        assert route.called
+        body = _json.loads(route.calls.last.request.content)
+        assert body == {"prompt_id": prompt_id}
+        assert prompt_id in result
 
 
 class TestGetJob:


### PR DESCRIPTION
## Summary
- Adopt ComfyUI's new unified `/api/jobs` endpoints. `comfyui_get_job` is migrated from `/history/{prompt_id}` to `/api/jobs/{job_id}`, fixing a real bug where it returned empty for queued or running jobs (the old endpoint only sees completed history).
- Add new `comfyui_list_jobs` tool with status filter, sorting, and offset-based pagination — replaces awkward client-side stitching of queue + history.
- Extend `comfyui_interrupt` with optional `prompt_id` to target a specific running prompt instead of always doing a global interrupt (closes a multi-user footgun).

### Breaking change
`comfyui_get_job` response shape changed from the legacy envelope `{prompt_id: {...}}` to the flat unified job object (top-level `prompt_id`, `status`, `outputs`, timing fields). Documented in the tool docstring.

## Test Plan
- [x] `uv run pytest` — 493 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/comfyui_mcp/` — no issues
- [x] `tests/test_security_invariants.py` confirms new `comfyui_list_jobs` closure has audit + rate limiter
- [x] Integration test (`tests/test_integration.py`) updated for the new `/api/jobs/{job_id}` response shape
- [ ] Smoke test against a live ComfyUI server: `comfyui_list_jobs(limit=1)`, `comfyui_get_job(prompt_id=...)`, `comfyui_interrupt(prompt_id=...)`

## Notes
Plan and review history in `docs/superpowers/plans/2026-05-10-jobs-api-and-targeted-interrupt.md` (uncommitted on this branch — leftover from planning, not part of the feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)