### PR TITLE
MCP best-practices cleanup: pagination, param renames, docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | `comfyui_upscale_image` | Upscale an image using a model-based upscaler. Params: image (filename), upscale_model (default: RealESRGAN_x4plus.pth). |
 | `comfyui_run_workflow` | Submit arbitrary ComfyUI workflow JSON. Inspected for dangerous nodes before execution. Set `wait=True` to block until complete and return outputs. |
 | `comfyui_run_workflow_stream` | Submit workflow JSON and capture ComfyUI websocket stream events (`progress`, `executing`, `executed`, etc.) until terminal status, returning events plus final outputs/status. |
-| `comfyui_summarize_workflow` | Summarize a workflow's structure, data flow, models, and parameters. Supports `format="text"` (default) or `format="mermaid"` for diagram markup. |
+| `comfyui_summarize_workflow` | Summarize a workflow's structure, data flow, models, and parameters. Supports `output_format="text"` (default) or `output_format="mermaid"` for diagram markup. |
 | `comfyui_create_workflow` | Create a workflow from templates including txt2img/img2img/upscale/inpaint, txt2vid_animatediff/txt2vid_wan, controlnet_canny/controlnet_depth/controlnet_openpose, ip_adapter, lora_stack, face_restore, flux_txt2img, and sdxl_txt2img. |
 | `comfyui_modify_workflow` | Apply batch operations (add_node, remove_node, set_input, connect, disconnect) to a workflow. |
 | `comfyui_validate_workflow` | Validate workflow structure, server compatibility, and security. |
@@ -272,9 +272,9 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | Tool | Description |
 |------|-------------|
 | `comfyui_search_custom_nodes` | Search ComfyUI Manager registry custom node packs by name/description/author. |
-| `comfyui_install_custom_node` | Queue install for a custom node pack by `id`; optional restart and post-install security audit. |
-| `comfyui_uninstall_custom_node` | Queue uninstall for a custom node pack by `id`; optional restart. |
-| `comfyui_update_custom_node` | Queue update for a custom node pack by `id`; optional restart and post-update security audit. |
+| `comfyui_install_custom_node` | Queue install for a custom node pack by `node_id`; optional restart and post-install security audit. |
+| `comfyui_uninstall_custom_node` | Queue uninstall for a custom node pack by `node_id`; optional restart. |
+| `comfyui_update_custom_node` | Queue update for a custom node pack by `node_id`; optional restart and post-update security audit. |
 | `comfyui_get_custom_node_status` | Get custom node queue status (pending/running/completed). |
 
 > **Requires:** ComfyUI-Manager available on the target ComfyUI server. If unavailable, node-management tools return a helpful error.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Tools expose Pydantic `Field` constraints on input parameters (ranges, lengths, 
 - **Output schemas**: 26 tools return structured data with auto-generated `outputSchema`, enabling clients to parse responses without guessing the shape
 - **Streamable HTTP transport**: Optional remote transport via `transport.remote.enabled` using the MCP spec's recommended Streamable HTTP protocol
 
+## Recent Breaking Changes (2026-05)
+
+**Parameter renames** — update keyword arguments (positional calls are unaffected):
+
+- `comfyui_install_custom_node`, `comfyui_uninstall_custom_node`, `comfyui_update_custom_node`: `id` → `node_id`.
+- `comfyui_summarize_workflow`: `format` → `output_format`, restricted to `text` or `mermaid` via a Pydantic `Literal`.
+
+**Response-shape changes** — these tools now return the standard pagination envelope `{items, total, offset, limit, has_more}` instead of bare lists or raw dicts:
+
+- `comfyui_list_extensions` (was: `list[str]`)
+- `comfyui_list_model_folders` (was: `list[str]`)
+- `comfyui_list_workflows` (was: `dict[package_name, list[template]]`; now flattened to `items: [{package, templates}]`)
+
+Callers must update to read `result["items"]` instead of indexing the response directly. The new envelope also exposes `limit` and `offset` parameters for pagination.
+
 ## Quick start
 
 ### Prerequisites

--- a/src/comfyui_mcp/pagination.py
+++ b/src/comfyui_mcp/pagination.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
+
+from pydantic import Field
 
 
 def paginate(
@@ -35,3 +37,22 @@ def paginate(
         "limit": effective_limit,
         "has_more": (effective_offset + effective_limit) < total,
     }
+
+
+LimitField = Annotated[
+    int,
+    Field(
+        ge=1,
+        le=100,
+        description="Maximum number of results to return (1-100, default varies by tool).",
+    ),
+]
+
+
+OffsetField = Annotated[
+    int,
+    Field(
+        ge=0,
+        description="Zero-based starting index for pagination.",
+    ),
+]

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -236,11 +236,29 @@ def register_discovery_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_list_workflows() -> dict[str, Any]:
-        """List available workflow templates."""
+    async def comfyui_list_workflows(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+        """List workflow templates registered on the ComfyUI server (the
+        ``/workflow_templates`` endpoint, populated by installed front-end packages).
+
+        This is distinct from ``comfyui_create_workflow``'s built-in template names
+        (txt2img, img2img, etc.) which are hard-coded in the MCP for graph generation.
+
+        Returns a paginated envelope: ``{items, total, offset, limit, has_more}``.
+        Each item is ``{"package": str, "templates": [...]}`` from the server.
+        """
         limiter.check("list_workflows")
         await audit.async_log(tool="list_workflows", action="called")
-        return await client.get_workflow_templates()
+        templates_by_package = await client.get_workflow_templates()
+        # client.get_workflow_templates returns dict[package_name, list[template]];
+        # flatten to a list of {package, templates} so paginate() can slice it.
+        items = [
+            {"package": package, "templates": templates}
+            for package, templates in (templates_by_package or {}).items()
+        ]
+        return paginate(items, offset, limit, default_limit=25, max_limit=100)
 
     tool_fns["comfyui_list_workflows"] = comfyui_list_workflows
 
@@ -252,11 +270,20 @@ def register_discovery_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_list_extensions() -> list[Any]:
-        """List available ComfyUI extensions."""
+    async def comfyui_list_extensions(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+        """List installed ComfyUI extensions (front-end / back-end JavaScript modules
+        registered with the ComfyUI server).
+
+        Returns a paginated envelope: ``{items, total, offset, limit, has_more}``.
+        Each item is the extension's URL/path string.
+        """
         limiter.check("list_extensions")
         await audit.async_log(tool="list_extensions", action="called")
-        return await client.get_extensions()
+        extensions = await client.get_extensions()
+        return paginate(extensions, offset, limit, default_limit=25, max_limit=100)
 
     tool_fns["comfyui_list_extensions"] = comfyui_list_extensions
 
@@ -284,11 +311,20 @@ def register_discovery_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_list_model_folders() -> list[Any]:
-        """List available model folder types (checkpoints, loras, vae, etc.)."""
+    async def comfyui_list_model_folders(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+        """List the model-folder types ComfyUI recognizes (checkpoints, loras, vae,
+        controlnet, etc.). Pass any returned name as the ``folder`` argument to
+        ``comfyui_list_models`` or ``comfyui_get_model_metadata``.
+
+        Returns a paginated envelope: ``{items, total, offset, limit, has_more}``.
+        """
         limiter.check("list_model_folders")
         await audit.async_log(tool="list_model_folders", action="called")
-        return await client.get_model_types()
+        folders = await client.get_model_types()
+        return paginate(folders, offset, limit, default_limit=25, max_limit=100)
 
     tool_fns["comfyui_list_model_folders"] = comfyui_list_model_folders
 

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
@@ -218,8 +219,24 @@ def register_discovery_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_get_node_info(node_class: str) -> dict[str, Any]:
-        """Get detailed information about a specific node type."""
+    async def comfyui_get_node_info(
+        node_class: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Node class name (e.g. 'KSampler', 'CLIPTextEncode'). "
+                "Use comfyui_list_nodes to discover available class names.",
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Get the input/output schema and metadata for a single ComfyUI node type.
+
+        Returns a dict with keys: input, input_order, is_input_list, output,
+        output_is_list, output_name, name, display_name, description, python_module,
+        category, output_node, search_aliases, plus optional flags like deprecated,
+        experimental, and api_node when set on the node.
+        """
         limiter.check("get_node_info")
         await audit.async_log(
             tool="get_node_info", action="called", extra={"node_class": node_class}
@@ -296,7 +313,13 @@ def register_discovery_tools(
         )
     )
     async def comfyui_get_server_features() -> dict[str, Any]:
-        """Get ComfyUI server features and capabilities."""
+        """Get the feature flags advertised by the ComfyUI server.
+
+        Returns the raw ``/features`` response — typically a dict of
+        {feature_name: bool}. Useful for capability-based branching, e.g.
+        checking ``supports_preview_metadata`` before requesting preview-format
+        images via ``comfyui_get_image``.
+        """
         limiter.check("get_server_features")
         await audit.async_log(tool="get_server_features", action="called")
         return await client.get_features()

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -10,7 +10,7 @@ from mcp.types import ToolAnnotations
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
-from comfyui_mcp.pagination import paginate
+from comfyui_mcp.pagination import LimitField, OffsetField, paginate
 from comfyui_mcp.security.node_auditor import NodeAuditor
 from comfyui_mcp.security.rate_limit import RateLimiter
 from comfyui_mcp.security.sanitizer import PathSanitizer
@@ -167,8 +167,8 @@ def register_discovery_tools(
     )
     async def comfyui_list_models(
         folder: str = "checkpoints",
-        limit: int = 25,
-        offset: int = 0,
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
     ) -> dict[str, Any]:
         """List available models in a folder (checkpoints, loras, vae, etc.).
 
@@ -193,7 +193,10 @@ def register_discovery_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_list_nodes(limit: int = 25, offset: int = 0) -> dict[str, Any]:
+    async def comfyui_list_nodes(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
         """List all available ComfyUI node types.
 
         Args:

--- a/src/comfyui_mcp/tools/files.py
+++ b/src/comfyui_mcp/tools/files.py
@@ -14,7 +14,7 @@ from pydantic import Field
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
-from comfyui_mcp.pagination import paginate
+from comfyui_mcp.pagination import LimitField, OffsetField, paginate
 from comfyui_mcp.security.rate_limit import RateLimiter
 from comfyui_mcp.security.sanitizer import PathSanitizer
 
@@ -204,7 +204,10 @@ def register_file_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_list_outputs(limit: int = 25, offset: int = 0) -> dict[str, Any]:
+    async def comfyui_list_outputs(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
         """List output files from ComfyUI's execution history.
 
         Args:

--- a/src/comfyui_mcp/tools/generation.py
+++ b/src/comfyui_mcp/tools/generation.py
@@ -435,6 +435,9 @@ def register_generation_tools(
     async def comfyui_run_workflow(workflow: str, wait: bool = False) -> str:
         """Submit an arbitrary ComfyUI workflow for execution.
 
+        See also: comfyui_run_workflow_stream for a streaming variant that emits
+        per-node progress events while the workflow executes.
+
         Args:
             workflow: JSON string of a ComfyUI workflow (API format).
                       Each key is a node ID, each value has 'class_type' and 'inputs'.
@@ -475,6 +478,12 @@ def register_generation_tools(
         execution updates (for example, `progress`, `executing`, `executed`).
         Events are filtered by `prompt_id` when that field is present in the
         websocket payload.
+
+        See also: comfyui_run_workflow for a non-streaming variant. Use this
+        streaming version when you need real-time per-node progress events
+        (intended for tooling that surfaces progress to a user); use the
+        non-streaming variant for fire-and-forget submission or when you only
+        need the final result.
 
         Args:
             workflow: JSON string of a ComfyUI workflow (API format).

--- a/src/comfyui_mcp/tools/generation.py
+++ b/src/comfyui_mcp/tools/generation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import json
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -550,24 +550,37 @@ def register_generation_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_summarize_workflow(workflow: str, format: str = "text") -> str:  # noqa: A002
+    async def comfyui_summarize_workflow(
+        workflow: Annotated[
+            str,
+            Field(
+                description="JSON string of a ComfyUI workflow (API format). "
+                "Each top-level key is a node ID, each value has 'class_type' and 'inputs'.",
+            ),
+        ],
+        output_format: Annotated[
+            Literal["text", "mermaid"],
+            Field(
+                default="text",
+                description="Output format: 'text' (human-readable summary) or "
+                "'mermaid' (Mermaid flowchart markup).",
+            ),
+        ] = "text",
+    ) -> str:
         """Summarize a ComfyUI workflow's structure, data flow, and key parameters.
 
         Parses the workflow graph, extracts models, parameters, and execution flow.
         Enriches with display names from the ComfyUI server when available.
-
-        Args:
-            workflow: JSON string of a ComfyUI workflow (API format).
-                      Each key is a node ID, each value has 'class_type' and 'inputs'.
-            format: Output format. "text" for human-readable summary (default),
-                    "mermaid" for Mermaid flowchart markup.
         """
         summary_limiter = read_limiter if read_limiter is not None else limiter
         summary_limiter.check("summarize_workflow")
 
-        output_format = format.lower().strip()
-        if output_format not in {"text", "mermaid"}:
-            raise ValueError('format must be either "text" or "mermaid"')
+        # Defense-in-depth: pydantic enforces Literal at the FastMCP boundary,
+        # but direct Python callers (including tests) bypass that. Keep the
+        # runtime check.
+        normalized_format = output_format.lower().strip() if isinstance(output_format, str) else ""
+        if normalized_format not in {"text", "mermaid"}:
+            raise ValueError('output_format must be either "text" or "mermaid"')
 
         try:
             wf = json.loads(workflow)
@@ -589,10 +602,10 @@ def register_generation_tools(
             extra={
                 "node_count": analysis["node_count"],
                 "pipeline": analysis["pipeline"],
-                "format": output_format,
+                "output_format": normalized_format,
             },
         )
-        if output_format == "mermaid":
+        if normalized_format == "mermaid":
             return _format_mermaid(analysis)
         return _format_summary(analysis)
 

--- a/src/comfyui_mcp/tools/history.py
+++ b/src/comfyui_mcp/tools/history.py
@@ -9,7 +9,7 @@ from mcp.types import ToolAnnotations
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
-from comfyui_mcp.pagination import paginate
+from comfyui_mcp.pagination import LimitField, OffsetField, paginate
 from comfyui_mcp.security.rate_limit import RateLimiter
 
 
@@ -30,7 +30,10 @@ def register_history_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_get_history(limit: int = 25, offset: int = 0) -> dict[str, Any]:
+    async def comfyui_get_history(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
         """Browse ComfyUI execution history (read-only).
 
         Covers up to the 1000 most recent history entries — older entries are

--- a/src/comfyui_mcp/tools/history.py
+++ b/src/comfyui_mcp/tools/history.py
@@ -33,13 +33,16 @@ def register_history_tools(
     async def comfyui_get_history(limit: int = 25, offset: int = 0) -> dict[str, Any]:
         """Browse ComfyUI execution history (read-only).
 
+        Covers up to the 1000 most recent history entries — older entries are
+        unreachable. Pagination operates over that window.
+
         Args:
             limit: Maximum number of results to return (default: 25, max: 100)
             offset: Starting index for pagination (default: 0)
         """
         limiter.check("get_history")
         await audit.async_log(tool="get_history", action="called")
-        raw = await client.get_history(max_items=100)
+        raw = await client.get_history(max_items=1000)
         entries = [{**(v if isinstance(v, dict) else {}), "prompt_id": k} for k, v in raw.items()]
         return paginate(entries, offset, limit, default_limit=25, max_limit=100)
 

--- a/src/comfyui_mcp/tools/nodes.py
+++ b/src/comfyui_mcp/tools/nodes.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import re
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
 from comfyui_mcp.node_manager import ComfyUIManagerDetector
-from comfyui_mcp.pagination import paginate
+from comfyui_mcp.pagination import OffsetField, paginate
 from comfyui_mcp.security.node_auditor import NodeAuditor
 from comfyui_mcp.security.rate_limit import RateLimiter
 
@@ -182,9 +183,25 @@ def register_node_tools(
         )
     )
     async def comfyui_search_custom_nodes(
-        query: str,
-        limit: int = 10,
-        offset: int = 0,
+        query: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Search term matched against installed node-pack name, "
+                "ID, description, and author.",
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                default=10,
+                ge=1,
+                le=25,
+                description="Maximum number of matches to return (1-25).",
+            ),
+        ] = 10,
+        offset: OffsetField = 0,
     ) -> dict[str, Any]:
         """Search installed custom node packs by name, description, or author.
 
@@ -271,14 +288,31 @@ def register_node_tools(
         )
     )
     async def comfyui_install_custom_node(
-        id: str,  # noqa: A002
-        version: str = "",
-        restart: bool = False,
+        node_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Custom-node pack ID from the ComfyUI Manager registry. "
+                "Use comfyui_search_custom_nodes to discover IDs.",
+            ),
+        ],
+        version: Annotated[
+            str,
+            Field(default="", description="Specific version to install. Empty string = latest."),
+        ] = "",
+        restart: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, restart ComfyUI after install and run a security audit.",
+            ),
+        ] = False,
     ) -> str:
         """Install a custom node pack from the ComfyUI Manager registry.
 
         Args:
-            id: Node pack ID from the registry (use search_custom_nodes to find IDs).
+            node_id: Node pack ID from the registry (use search_custom_nodes to find IDs).
             version: Specific version to install (empty string = latest).
             restart: If True, restart ComfyUI after install and run a security audit
                      on all installed nodes. If False, manual restart is needed.
@@ -288,25 +322,25 @@ def register_node_tools(
         """
         wf_limiter.check("install_custom_node")
         await node_manager.require_available()
-        _validate_node_id(id)
+        _validate_node_id(node_id)
 
         await audit.async_log(
             tool="install_custom_node",
             action="installing",
-            extra={"id": id, "version": version},
+            extra={"node_id": node_id, "version": version},
         )
 
         result = await _execute_node_operation(
             client=client,
             kind="install",
             params={
-                "id": id,
+                "id": node_id,
                 "version": version or "latest",
                 "selected_version": version or "latest",
                 "mode": "remote",
                 "channel": "default",
             },
-            node_id=id,
+            node_id=node_id,
             restart=restart,
             node_auditor=node_auditor,
             audit=audit,
@@ -317,7 +351,7 @@ def register_node_tools(
         await audit.async_log(
             tool="install_custom_node",
             action="completed",
-            extra={"id": id, "version": version, "restart": restart},
+            extra={"node_id": node_id, "version": version, "restart": restart},
         )
 
         return result
@@ -333,13 +367,23 @@ def register_node_tools(
         )
     )
     async def comfyui_uninstall_custom_node(
-        id: str,  # noqa: A002
-        restart: bool = False,
+        node_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Custom-node pack ID to uninstall.",
+            ),
+        ],
+        restart: Annotated[
+            bool,
+            Field(default=False, description="If True, restart ComfyUI after uninstall."),
+        ] = False,
     ) -> str:
         """Uninstall a custom node pack.
 
         Args:
-            id: Node pack ID to uninstall.
+            node_id: Node pack ID to uninstall.
             restart: If True, restart ComfyUI after uninstall.
 
         Returns:
@@ -347,19 +391,19 @@ def register_node_tools(
         """
         wf_limiter.check("uninstall_custom_node")
         await node_manager.require_available()
-        _validate_node_id(id)
+        _validate_node_id(node_id)
 
         await audit.async_log(
             tool="uninstall_custom_node",
             action="uninstalling",
-            extra={"id": id},
+            extra={"node_id": node_id},
         )
 
         result = await _execute_node_operation(
             client=client,
             kind="uninstall",
-            params={"node_name": id, "is_unknown": False},
-            node_id=id,
+            params={"node_name": node_id, "is_unknown": False},
+            node_id=node_id,
             restart=restart,
             node_auditor=node_auditor,
             audit=audit,
@@ -370,7 +414,7 @@ def register_node_tools(
         await audit.async_log(
             tool="uninstall_custom_node",
             action="completed",
-            extra={"id": id, "restart": restart},
+            extra={"node_id": node_id, "restart": restart},
         )
 
         return result
@@ -386,13 +430,26 @@ def register_node_tools(
         )
     )
     async def comfyui_update_custom_node(
-        id: str,  # noqa: A002
-        restart: bool = False,
+        node_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Custom-node pack ID to update to the latest version.",
+            ),
+        ],
+        restart: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, restart ComfyUI after update and run a security audit.",
+            ),
+        ] = False,
     ) -> str:
         """Update a custom node pack to the latest version.
 
         Args:
-            id: Node pack ID to update.
+            node_id: Node pack ID to update.
             restart: If True, restart ComfyUI after update and run a security audit
                      on all installed nodes.
 
@@ -401,19 +458,19 @@ def register_node_tools(
         """
         wf_limiter.check("update_custom_node")
         await node_manager.require_available()
-        _validate_node_id(id)
+        _validate_node_id(node_id)
 
         await audit.async_log(
             tool="update_custom_node",
             action="updating",
-            extra={"id": id},
+            extra={"node_id": node_id},
         )
 
         result = await _execute_node_operation(
             client=client,
             kind="update",
-            params={"node_name": id, "node_ver": None},
-            node_id=id,
+            params={"node_name": node_id, "node_ver": None},
+            node_id=node_id,
             restart=restart,
             node_auditor=node_auditor,
             audit=audit,
@@ -424,7 +481,7 @@ def register_node_tools(
         await audit.async_log(
             tool="update_custom_node",
             action="completed",
-            extra={"id": id, "restart": restart},
+            extra={"node_id": node_id, "restart": restart},
         )
 
         return result

--- a/src/comfyui_mcp/tools/nodes.py
+++ b/src/comfyui_mcp/tools/nodes.py
@@ -30,11 +30,11 @@ _RESTART_SETTLE_DELAY = 5
 def _validate_node_id(node_id: str) -> str:
     """Validate a node pack ID."""
     if not node_id:
-        raise ValueError("id must not be empty")
+        raise ValueError("node_id must not be empty")
     if len(node_id) > 200:
-        raise ValueError("id must not exceed 200 characters")
+        raise ValueError("node_id must not exceed 200 characters")
     if _CONTROL_CHAR_RE.search(node_id):
-        raise ValueError(f"id contains invalid characters: {node_id!r}")
+        raise ValueError(f"node_id contains invalid characters: {node_id!r}")
     return node_id
 
 

--- a/src/comfyui_mcp/tools/workflow.py
+++ b/src/comfyui_mcp/tools/workflow.py
@@ -181,7 +181,7 @@ def register_workflow_tools(
             workflow: JSON string of the workflow to validate.
 
         Returns:
-            JSON string with: valid (bool), errors (list), warnings (list),
+            Dict with keys: valid (bool), errors (list), warnings (list),
             node_count (int), pipeline (str).
         """
         limiter.check("validate_workflow")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -75,3 +75,21 @@ class TestPaginate:
     def test_envelope_keys(self):
         result = paginate([1, 2, 3])
         assert set(result.keys()) == {"items", "total", "offset", "limit", "has_more"}
+
+
+def test_limit_field_and_offset_field_schema_constraints():
+    from pydantic import BaseModel
+
+    from comfyui_mcp.pagination import LimitField, OffsetField
+
+    class _Model(BaseModel):
+        limit: LimitField = 25
+        offset: OffsetField = 0
+
+    schema = _Model.model_json_schema()
+    assert schema["properties"]["limit"]["minimum"] == 1
+    assert schema["properties"]["limit"]["maximum"] == 100
+    assert schema["properties"]["offset"]["minimum"] == 0
+    # Description present
+    assert "results" in schema["properties"]["limit"]["description"].lower()
+    assert "pagination" in schema["properties"]["offset"]["description"].lower()

--- a/tests/test_tools_discovery.py
+++ b/tests/test_tools_discovery.py
@@ -103,7 +103,34 @@ class TestListExtensions:
         tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
 
         result = await tools["comfyui_list_extensions"]()
-        assert len(result) == 2
+        assert result["items"] == ["ext1", "ext2"]
+        assert result["total"] == 2
+        assert result["offset"] == 0
+        assert result["has_more"] is False
+
+
+class TestListWorkflows:
+    @respx.mock
+    async def test_list_workflows_paginates(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/workflow_templates").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ComfyUI-Manager": ["templ_a", "templ_b"],
+                    "ComfyUI-Frontend": ["templ_c"],
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_list_workflows"]()
+        assert "items" in result
+        assert result["total"] == 2  # two packages, not three templates
+        assert result["has_more"] is False
+        package_names = {entry["package"] for entry in result["items"]}
+        assert package_names == {"ComfyUI-Manager", "ComfyUI-Frontend"}
 
 
 class TestGetServerFeatures:
@@ -131,8 +158,10 @@ class TestListModelFolders:
         tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
 
         result = await tools["comfyui_list_model_folders"]()
-        assert "checkpoints" in result
-        assert "loras" in result
+        assert "checkpoints" in result["items"]
+        assert "loras" in result["items"]
+        assert result["total"] == 3
+        assert result["has_more"] is False
 
 
 class TestGetModelMetadata:

--- a/tests/test_tools_generation.py
+++ b/tests/test_tools_generation.py
@@ -689,7 +689,7 @@ class TestSummarizeWorkflow:
         }
         result = await tools["comfyui_summarize_workflow"](
             workflow=json.dumps(workflow),
-            format="mermaid",
+            output_format="mermaid",
         )
         assert "<script>" not in result
         assert "&lt;script&gt;" in result
@@ -741,7 +741,7 @@ class TestSummarizeWorkflow:
 
         result = await tools["comfyui_summarize_workflow"](
             workflow=json.dumps(workflow),
-            format="mermaid",
+            output_format="mermaid",
         )
 
         assert "flowchart LR" in result
@@ -765,8 +765,8 @@ class TestSummarizeWorkflow:
             sanitizer=sanitizer,
         )
 
-        with pytest.raises(ValueError, match='format must be either "text" or "mermaid"'):
-            await tools["comfyui_summarize_workflow"](workflow="{}", format="yaml")
+        with pytest.raises(ValueError, match='output_format must be either "text" or "mermaid"'):
+            await tools["comfyui_summarize_workflow"](workflow="{}", output_format="yaml")
 
 
 class TestGenerateImageWait:

--- a/tests/test_tools_history.py
+++ b/tests/test_tools_history.py
@@ -65,3 +65,19 @@ class TestGetHistory:
         prompt_ids = [item["prompt_id"] for item in result["items"]]
         assert "abc" in prompt_ids
         assert "bad" in prompt_ids
+
+    @respx.mock
+    async def test_passes_1000_cap_to_client(self, components):
+        # The tool should request up to 1000 history items from the client
+        # so that pagination can report a meaningful `total` for callers paging
+        # through history.
+        client, audit, limiter = components
+        route = respx.get("http://test:8188/history").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_history_tools(mcp, client, audit, limiter)
+        await tools["comfyui_get_history"]()
+        request = route.calls.last.request
+        params = dict(request.url.params.multi_items())
+        assert params.get("max_items") == "1000"

--- a/tests/test_tools_nodes.py
+++ b/tests/test_tools_nodes.py
@@ -202,7 +202,7 @@ class TestInstallCustomNode:
         respx.post(f"{BASE}/v2/manager/queue/task").mock(return_value=httpx.Response(200))
         _mock_operation_success()
         result = await registered_tools["comfyui_install_custom_node"](
-            id="comfy-pack-one", restart=False
+            node_id="comfy-pack-one", restart=False
         )
         assert "completed" in result.lower() or "operation completed" in result.lower()
         assert "Restart required" in result
@@ -214,7 +214,7 @@ class TestInstallCustomNode:
         _mock_operation_success()
         _mock_restart_success(with_audit=True)
         result = await registered_tools["comfyui_install_custom_node"](
-            id="comfy-pack-one", restart=True
+            node_id="comfy-pack-one", restart=True
         )
         assert "restarted" in result.lower()
         assert "nodes scanned" in result.lower()
@@ -226,22 +226,22 @@ class TestInstallCustomNode:
         _mock_operation_success()
         _mock_restart_busy_queue()
         result = await registered_tools["comfyui_install_custom_node"](
-            id="comfy-pack-one", restart=True
+            node_id="comfy-pack-one", restart=True
         )
         assert "deferred" in result.lower()
         assert "1 job(s) in queue" in result
 
     async def test_validates_empty_id(self, registered_tools):
         with pytest.raises(ValueError, match="must not be empty"):
-            await registered_tools["comfyui_install_custom_node"](id="")
+            await registered_tools["comfyui_install_custom_node"](node_id="")
 
     async def test_validates_control_chars(self, registered_tools):
         with pytest.raises(ValueError, match="invalid characters"):
-            await registered_tools["comfyui_install_custom_node"](id="bad\x00id")
+            await registered_tools["comfyui_install_custom_node"](node_id="bad\x00id")
 
     async def test_validates_too_long_id(self, registered_tools):
         with pytest.raises(ValueError, match="must not exceed 200"):
-            await registered_tools["comfyui_install_custom_node"](id="x" * 201)
+            await registered_tools["comfyui_install_custom_node"](node_id="x" * 201)
 
     @respx.mock
     @patch("comfyui_mcp.tools.nodes.asyncio.sleep", new_callable=AsyncMock)
@@ -249,7 +249,9 @@ class TestInstallCustomNode:
         respx.post(f"{BASE}/v2/manager/queue/task").mock(return_value=httpx.Response(200))
         _mock_operation_success()
         # First call succeeds
-        await registered_tools["comfyui_install_custom_node"](id="comfy-pack-one", restart=False)
+        await registered_tools["comfyui_install_custom_node"](
+            node_id="comfy-pack-one", restart=False
+        )
         # Exhaust the rate limiter
         limiter = components["wf_limiter"]
         for _ in range(120):
@@ -261,7 +263,7 @@ class TestInstallCustomNode:
 
         with pytest.raises(RateLimitError):
             await registered_tools["comfyui_install_custom_node"](
-                id="comfy-pack-one", restart=False
+                node_id="comfy-pack-one", restart=False
             )
 
 
@@ -272,7 +274,7 @@ class TestUninstallCustomNode:
         respx.post(f"{BASE}/v2/manager/queue/task").mock(return_value=httpx.Response(200))
         _mock_operation_success()
         result = await registered_tools["comfyui_uninstall_custom_node"](
-            id="comfy-pack-one", restart=False
+            node_id="comfy-pack-one", restart=False
         )
         assert "operation completed" in result.lower()
         assert "Restart required" in result
@@ -286,7 +288,7 @@ class TestUninstallCustomNode:
         # No audit: restart without object_info mock
         _mock_restart_success(with_audit=False)
         result = await registered_tools["comfyui_uninstall_custom_node"](
-            id="comfy-pack-one", restart=True
+            node_id="comfy-pack-one", restart=True
         )
         assert "restarted successfully" in result.lower()
         # Should NOT contain audit results
@@ -300,7 +302,7 @@ class TestUpdateCustomNode:
         respx.post(f"{BASE}/v2/manager/queue/task").mock(return_value=httpx.Response(200))
         _mock_operation_success()
         result = await registered_tools["comfyui_update_custom_node"](
-            id="comfy-pack-one", restart=False
+            node_id="comfy-pack-one", restart=False
         )
         assert "operation completed" in result.lower()
         assert "Restart required" in result
@@ -313,7 +315,7 @@ class TestUpdateCustomNode:
         _mock_operation_success()
         _mock_restart_success(with_audit=True)
         result = await registered_tools["comfyui_update_custom_node"](
-            id="comfy-pack-one", restart=True
+            node_id="comfy-pack-one", restart=True
         )
         assert "restarted" in result.lower()
         assert "nodes scanned" in result.lower()
@@ -325,7 +327,7 @@ class TestUpdateCustomNode:
         respx.post(f"{BASE}/v2/manager/queue/task").mock(return_value=httpx.Response(200))
         _mock_operation_success()
         _mock_restart_success(with_audit=True)
-        await registered_tools["comfyui_update_custom_node"](id="comfy-pack-one", restart=True)
+        await registered_tools["comfyui_update_custom_node"](node_id="comfy-pack-one", restart=True)
         audit_path = components["tmp_path"] / "audit.log"
         lines = audit_path.read_text().strip().split("\n")
         actions = [json.loads(line)["action"] for line in lines]


### PR DESCRIPTION
## Summary

Address six findings from a best-practices audit of the comfyui_mcp tool surface. **Five of these are deliberate breaking changes** for MCP callers — flagged in commit messages and a new "Recent Breaking Changes" README section.

### Changes

- **Pagination correctness:** `comfyui_get_history` previously capped its upstream fetch at 100 items and reported that cap as `total`, so callers paging beyond offset 75 saw `has_more: false` even when more history existed. Bumped to 1000 (the client's hard cap).
- **Pagination consistency:** Added shared `LimitField` / `OffsetField` Annotated type aliases to `pagination.py` so list tools advertise `ge`/`le` constraints in their MCP JSON schemas. Applied to `get_history`, `list_models`, `list_nodes`, `list_outputs`.
- **Pagination coverage:** Wrapped three holdout list tools (`comfyui_list_extensions`, `comfyui_list_model_folders`, `comfyui_list_workflows`) in the standard envelope. **Breaking response shape** — see migration notes below.
- **Parameter renames (BREAKING):** `comfyui_install_custom_node`, `comfyui_uninstall_custom_node`, `comfyui_update_custom_node` — `id` → `node_id` (drops `# noqa: A002` builtin shadowing). `comfyui_summarize_workflow` — `format` → `output_format` with `Literal["text", "mermaid"]` type. Wire-level dict keys to the upstream ComfyUI Manager API are unchanged.
- **Schema-level constraints:** Added `Field(min_length, max_length, description)` to node-tool parameters and `comfyui_get_node_info`'s `node_class` so the constraints surface in the JSON schema.
- **Docstrings:** Beefed up stub docstrings on `list_extensions`, `list_model_folders`, `list_workflows`, `get_server_features`, `get_node_info`. Cross-referenced `run_workflow` and `run_workflow_stream`. Fixed `validate_workflow` docstring claim about return type.

### Migration

For MCP callers passing the renamed parameters by keyword:

- `comfyui_install_custom_node(id=...)` → `comfyui_install_custom_node(node_id=...)`
- `comfyui_uninstall_custom_node(id=...)` → `comfyui_uninstall_custom_node(node_id=...)`
- `comfyui_update_custom_node(id=...)` → `comfyui_update_custom_node(node_id=...)`
- `comfyui_summarize_workflow(format=...)` → `comfyui_summarize_workflow(output_format=...)`

For callers indexing the response of paginated list tools:

- `result[0]` → `result["items"][0]`
- The new envelope also exposes `limit` and `offset` parameters.

Audit-log keys also shift from `id` to `node_id` and `format` to `output_format` for log forwarders that key on those names.

## Test Plan

- [x] `uv run pytest` — 477 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/comfyui_mcp/` — no issues
- [x] All `# noqa: A002` markers removed from `src/comfyui_mcp/tools/`
- [x] Tool count unchanged (44 `@mcp.tool` decorators) — pure refactor, no new or removed tools
- [x] Wire-level params to ComfyUI Manager preserved (`{"id": ...}` for install, `{"node_name": ...}` for uninstall/update) — verified by inspection
- [ ] Smoke test against a live ComfyUI server: `comfyui_list_extensions(limit=5)`, `comfyui_install_custom_node(node_id="...", restart=False)`, `comfyui_summarize_workflow(workflow=..., output_format="mermaid")`

## Notes

- Branched off `main`, independent of PR #69 (`feature/unified-jobs-api`). The two PRs only touch overlapping files in `README.md` (#69 adds a row to the Job Management table; this one adds a new "Recent Breaking Changes" section near the top). Should merge cleanly.
- Plan and review history in `docs/superpowers/plans/2026-05-10-mcp-best-practices-cleanup.md` (uncommitted on this branch — leftover from planning, not part of the feature).
- Follow-ups out of scope for this PR (see plan): broader Field-annotation drift in upload tools (touches sanitizer layer); unified return envelope for `wait=True` generation tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)