### PR TITLE
Small cleanups: bump pre-commit ruff + fix skill doc references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -8,7 +8,7 @@ Create and optionally run a ComfyUI workflow. Template or description: "$ARGUMEN
 
 ## Steps
 
-1. **List available templates.** If no specific template was requested, call `comfyui_list_workflows` to show the available built-in templates (txt2img, img2img, etc.) and let the user choose.
+1. **Pick a template.** If no specific template was requested, choose from the built-in template names accepted by `comfyui_create_workflow`: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The full list is also in `comfyui_create_workflow`'s docstring. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — *not* these MCP-built-in templates.)
 
 2. **Create the workflow.** Call `comfyui_create_workflow` with the chosen template name and any parameters the user specified (as a JSON string). For example:
    ```

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -65,7 +65,7 @@ ComfyUI workflows use a JSON format where each node is a key-value pair:
 
 ## Using the Workflow Tools
 
-1. **`comfyui_create_workflow`** — Start from a template. Available templates can be listed with `comfyui_list_workflows`.
+1. **`comfyui_create_workflow`** — Start from a built-in template. The accepted template names are listed in the tool's docstring: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — a different set, not these MCP-built-in templates.)
 2. **`comfyui_modify_workflow`** — Add/remove nodes, change connections, update parameters on an existing workflow.
 3. **`comfyui_validate_workflow`** — Check for missing connections, unknown node types, and potential issues.
 4. **`comfyui_summarize_workflow`** — Get a human-readable description of what a workflow does.

--- a/tests/test_security_invariants.py
+++ b/tests/test_security_invariants.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -77,7 +78,7 @@ WORKFLOW_SUBMITTING_TOOLS: frozenset[str] = frozenset(
 
 
 @pytest.fixture
-def all_tools(tmp_path: Any) -> Iterator[dict[str, Any]]:
+def all_tools(tmp_path: Path) -> Iterator[dict[str, Any]]:
     """Build every tool from every register_*_tools() with real wiring.
 
     Mirrors server.py:_build_server() but skips FastMCP transport setup.


### PR DESCRIPTION
## Summary

Two small cleanups identified during the review of PR #70 (both flagged as "Minor / follow-up" at the time):

- **Bump `astral-sh/ruff-pre-commit` from `v0.8.6` to `v0.15.12`** to align the pre-commit hook with the `0.15.4` version that `uv sync` installs in the venv. Eliminates the spurious reformat diffs the older version was producing on files unchanged by the developer (e.g. `tests/test_blocked_endpoints.py`), making `uv run pre-commit run --all-files` and `uv run ruff format --check` agree.
- **Fix two skill files** (`skills/workflow/SKILL.md`, `skills/workflows/SKILL.md`) that told agents to call `comfyui_list_workflows` to discover the built-in templates accepted by `comfyui_create_workflow` (txt2img, img2img, etc.). Those tools point at different things: `comfyui_list_workflows` proxies the server's `/workflow_templates` endpoint (front-end packages registered with ComfyUI), while `comfyui_create_workflow` accepts a hard-coded set defined in `src/comfyui_mcp/workflow/templates.py`. The fix inlines the actual built-in template names and adds a one-line clarification.

## Test Plan

- [x] `uv run pytest` — 496 passed
- [x] `uv run pre-commit run --all-files` — all hooks pass; no spurious reformats
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/comfyui_mcp/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)