### PR TITLE
Upstream API updates: /view preview thumbnails, /upload/image destination, /history offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ The `comfyui_download_model` tool always sends a `previewFile` field (required b
 
 | Tool | Description |
 |------|-------------|
-| `comfyui_upload_image` | Upload a base64-encoded image to ComfyUI's input directory. Path-sanitized. |
-| `comfyui_get_image` | Download a generated image. `response_format="data_uri"` (default) returns inline base64; `response_format="url"` returns a direct `/view` URL. Optional `base_url_override` can override URL host per call. Path-sanitized. |
+| `comfyui_upload_image` | Upload a base64-encoded image to ComfyUI. Path-sanitized. Params: filename, image_data, subfolder, `destination="input"\|"output"\|"temp"` (default `input`), `overwrite` (default False — ComfyUI auto-renames duplicates). |
+| `comfyui_get_image` | Download a generated image. `response_format="data_uri"` (default) returns inline base64; `response_format="url"` returns a direct `/view` URL. With `data_uri`, optional `preview_format="webp"\|"jpeg"` + `preview_quality=1-100` request a server-rendered thumbnail (smaller payload, lossy). Optional `base_url_override` can override URL host per call. Path-sanitized. |
 | `comfyui_list_outputs` | List generated output filenames from history. |
 | `comfyui_upload_mask` | Upload a mask image to ComfyUI's input directory. Path-sanitized. |
 | `comfyui_get_workflow_from_image` | Extract embedded workflow and prompt metadata from a ComfyUI-generated PNG. |

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -155,12 +155,29 @@ class ComfyUIClient:
         self._object_info_ts = now
         return data
 
-    async def get_history(self, max_items: int | None = None) -> dict:
+    async def get_history(
+        self,
+        max_items: int | None = None,
+        *,
+        offset: int | None = None,
+    ) -> dict:
+        """GET /history — fetch execution history with optional pagination.
+
+        Args:
+            max_items: Maximum number of history entries to return. Capped at 1000
+                server-side regardless of the value passed.
+            offset: Zero-based starting index. None (default) sends no offset, which
+                ComfyUI treats as "no offset" (newest entries first).
+        """
         params: dict[str, int] = {}
         if max_items is not None:
             if max_items <= 0:
                 raise ValueError("max_items must be a positive integer")
             params["max_items"] = min(max_items, 1000)
+        if offset is not None:
+            if offset < 0:
+                raise ValueError("offset must be >= 0")
+            params["offset"] = offset
         r = await self._request("get", "/history", params=params or None)
         return r.json()
 

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -237,11 +237,42 @@ class ComfyUIClient:
         _validate_prompt_id(prompt_id)
         await self._request("post", "/queue", json={"delete": [prompt_id]})
 
-    async def upload_image(self, data: bytes, filename: str, subfolder: str = "") -> dict:
+    async def upload_image(
+        self,
+        data: bytes,
+        filename: str,
+        subfolder: str = "",
+        *,
+        destination: str = "input",
+        overwrite: bool = False,
+    ) -> dict:
+        """POST /upload/image — upload an image to ComfyUI.
+
+        Args:
+            data: Raw image bytes.
+            filename: Target filename in ComfyUI's storage.
+            subfolder: Optional subfolder within the destination.
+            destination: Destination type. One of "input" (default), "output", "temp".
+                The wire field name is ``type`` — renamed here to avoid shadowing the
+                Python builtin.
+            overwrite: If True, replace an existing file with the same name. If False
+                (default), ComfyUI auto-renames by suffixing ``(N)`` when a duplicate
+                exists.
+        """
+        if destination not in {"input", "output", "temp"}:
+            raise ValueError(
+                f"destination must be one of 'input', 'output', 'temp'; got {destination!r}"
+            )
         files = {"image": (filename, data, "image/png")}
         form_data: dict[str, str] = {}
         if subfolder:
             form_data["subfolder"] = subfolder
+        # Only include 'type'/'overwrite' when the caller deviates from defaults —
+        # keeps the request body identical to historical behavior in the common case.
+        if destination != "input":
+            form_data["type"] = destination
+        if overwrite:
+            form_data["overwrite"] = "true"
         r = await self._request("post", "/upload/image", files=files, data=form_data)
         return r.json()
 

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -249,13 +249,26 @@ class ComfyUIClient:
         self,
         filename: str,
         subfolder: str = "",
+        *,
+        preview: str | None = None,
     ) -> tuple[bytes, str]:
-        """GET /view — download an output image by filename and subfolder."""
-        r = await self._request(
-            "get",
-            "/view",
-            params={"filename": filename, "subfolder": subfolder, "type": "output"},
-        )
+        """GET /view — download an output image by filename and subfolder.
+
+        Args:
+            filename: Image filename in ComfyUI's output dir.
+            subfolder: Subfolder within ComfyUI's output dir.
+            preview: Optional thumbnail spec passed to ComfyUI as ``preview=<spec>``.
+                Format ``<format>;<quality>`` where format is ``webp`` or ``jpeg``
+                and quality is 1-100. ComfyUI re-encodes the image server-side.
+        """
+        params: dict[str, str] = {
+            "filename": filename,
+            "subfolder": subfolder,
+            "type": "output",
+        }
+        if preview is not None:
+            params["preview"] = preview
+        r = await self._request("get", "/view", params=params)
         content_type = r.headers.get("content-type", "image/png")
         return r.content, content_type
 

--- a/src/comfyui_mcp/tools/files.py
+++ b/src/comfyui_mcp/tools/files.py
@@ -225,10 +225,11 @@ def register_file_tools(
             When response_format='data_uri' and preview_format is set, ComfyUI re-encodes
             the image server-side as a smaller webp or jpeg thumbnail.
         """
+        limiter.check("get_image")
+
         if preview_quality is not None and preview_format is None:
             raise ValueError("preview_quality is only meaningful when preview_format is also set")
 
-        limiter.check("get_image")
         clean_name = sanitizer.validate_filename(filename)
         clean_subfolder = sanitizer.validate_subfolder(subfolder)
         await audit.async_log(

--- a/src/comfyui_mcp/tools/files.py
+++ b/src/comfyui_mcp/tools/files.py
@@ -109,13 +109,41 @@ def register_file_tools(
             openWorldHint=True,
         )
     )
-    async def comfyui_upload_image(filename: str, image_data: str, subfolder: str = "") -> str:
-        """Upload an image to ComfyUI's input directory.
+    async def comfyui_upload_image(
+        filename: Annotated[
+            str,
+            Field(description="Name for the uploaded file (e.g. 'reference.png')"),
+        ],
+        image_data: Annotated[
+            str,
+            Field(description="Base64-encoded image data"),
+        ],
+        subfolder: Annotated[
+            str,
+            Field(default="", description="Optional subfolder within the destination directory"),
+        ] = "",
+        destination: Annotated[
+            Literal["input", "output", "temp"],
+            Field(
+                default="input",
+                description="Destination directory. 'input' (default) is where workflows "
+                "read user-supplied images from; 'output' and 'temp' are usually only "
+                "useful for testing or scripted setups.",
+            ),
+        ] = "input",
+        overwrite: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, replace any existing file with the same name. If False "
+                "(default), ComfyUI auto-renames by suffixing ' (N)'.",
+            ),
+        ] = False,
+    ) -> str:
+        """Upload an image to ComfyUI.
 
-        Args:
-            filename: Name for the uploaded file (e.g. 'reference.png')
-            image_data: Base64-encoded image data
-            subfolder: Optional subfolder within ComfyUI's input directory
+        Defaults to ComfyUI's input directory (the destination workflows read from).
+        Set destination='output' or 'temp' only if you have a specific reason.
         """
         limiter.check("upload_image")
         clean_name = sanitizer.validate_filename(filename)
@@ -125,11 +153,22 @@ def register_file_tools(
         await audit.async_log(
             tool="upload_image",
             action="uploading",
-            extra={"filename": clean_name, "size_bytes": len(raw)},
+            extra={
+                "filename": clean_name,
+                "size_bytes": len(raw),
+                "destination": destination,
+                "overwrite": overwrite,
+            },
         )
-        result = await client.upload_image(raw, clean_name, clean_subfolder)
+        result = await client.upload_image(
+            raw,
+            clean_name,
+            clean_subfolder,
+            destination=destination,
+            overwrite=overwrite,
+        )
         await audit.async_log(tool="upload_image", action="uploaded", extra={"result": result})
-        return f"Uploaded {result.get('name', clean_name)} to ComfyUI input directory"
+        return f"Uploaded {result.get('name', clean_name)} to ComfyUI {destination} directory"
 
     tool_fns["comfyui_upload_image"] = comfyui_upload_image
 

--- a/src/comfyui_mcp/tools/files.py
+++ b/src/comfyui_mcp/tools/files.py
@@ -160,24 +160,54 @@ def register_file_tools(
                 description="Optional override for URL responses; falls back to configured base URL"
             ),
         ] = None,
+        preview_format: Annotated[
+            Literal["webp", "jpeg"] | None,
+            Field(
+                default=None,
+                description="If set with response_format='data_uri', request a server-rendered "
+                "thumbnail in this format instead of the original (smaller payload, lossy).",
+            ),
+        ] = None,
+        preview_quality: Annotated[
+            int | None,
+            Field(
+                default=None,
+                ge=1,
+                le=100,
+                description="Encoder quality (1-100) for preview_format. Default: 90 when "
+                "preview_format is set.",
+            ),
+        ] = None,
     ) -> str:
         """Download a generated image from ComfyUI or return a direct view URL.
 
         Returns:
-            Base64-encoded image data with content type prefix, or a direct image URL
+            Base64-encoded image data with content type prefix, or a direct image URL.
+            When response_format='data_uri' and preview_format is set, ComfyUI re-encodes
+            the image server-side as a smaller webp or jpeg thumbnail.
         """
+        if preview_quality is not None and preview_format is None:
+            raise ValueError("preview_quality is only meaningful when preview_format is also set")
+
         limiter.check("get_image")
         clean_name = sanitizer.validate_filename(filename)
         clean_subfolder = sanitizer.validate_subfolder(subfolder)
         await audit.async_log(
             tool="get_image",
             action="downloading",
-            extra={"filename": clean_name, "response_format": response_format},
+            extra={
+                "filename": clean_name,
+                "response_format": response_format,
+                "preview_format": preview_format,
+            },
         )
 
         resolved_base_url = base_url_override or image_view_base_url
 
         if response_format == "url":
+            # Preview params don't apply to URL responses — the returned URL
+            # is a direct /view link; callers wanting a thumbnail should
+            # request response_format='data_uri'.
             return client.build_image_url(
                 clean_name,
                 clean_subfolder,
@@ -187,9 +217,15 @@ def register_file_tools(
         if response_format != "data_uri":
             raise ValueError("response_format must be 'data_uri' or 'url'")
 
+        preview_spec: str | None = None
+        if preview_format is not None:
+            quality = preview_quality if preview_quality is not None else 90
+            preview_spec = f"{preview_format};{quality}"
+
         data, content_type = await client.get_image(
             clean_name,
             clean_subfolder,
+            preview=preview_spec,
         )
         b64 = base64.b64encode(data).decode()
         return f"data:{content_type};base64,{b64}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -461,6 +461,29 @@ class TestComfyUIClient:
         assert request.url.params["max_items"] == "50"
 
     @respx.mock
+    async def test_get_history_with_offset(self, client):
+        route = respx.get("http://test-comfyui:8188/history").mock(
+            return_value=httpx.Response(200, json={"abc": {"outputs": {}}})
+        )
+        await client.get_history(max_items=100, offset=50)
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["offset"] == "50"
+        assert params["max_items"] == "100"
+
+    @respx.mock
+    async def test_get_history_without_offset_omits_param(self, client):
+        route = respx.get("http://test-comfyui:8188/history").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        await client.get_history(max_items=100)
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert "offset" not in params
+
+    async def test_get_history_rejects_negative_offset(self, client):
+        with pytest.raises(ValueError, match="offset"):
+            await client.get_history(max_items=100, offset=-1)
+
+    @respx.mock
     async def test_get_object_info_cache_returns_cached(self, client):
         route = respx.get("http://test-comfyui:8188/object_info").mock(
             return_value=httpx.Response(200, json={"KSampler": {"input": {}}})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -206,6 +206,49 @@ class TestComfyUIClient:
         assert request.url.params["type"] == "output"
 
     @respx.mock
+    async def test_get_image_preview_webp(self, client):
+        route = respx.get("http://test-comfyui:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"fake-webp-bytes",
+                headers={"content-type": "image/webp"},
+            )
+        )
+        data, content_type = await client.get_image("out.png", preview="webp;90")
+        assert data == b"fake-webp-bytes"
+        assert content_type == "image/webp"
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["filename"] == "out.png"
+        assert params["preview"] == "webp;90"
+        assert params["type"] == "output"
+
+    @respx.mock
+    async def test_get_image_preview_jpeg(self, client):
+        route = respx.get("http://test-comfyui:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"fake-jpeg-bytes",
+                headers={"content-type": "image/jpeg"},
+            )
+        )
+        await client.get_image("out.png", preview="jpeg;75")
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["preview"] == "jpeg;75"
+
+    @respx.mock
+    async def test_get_image_without_preview_omits_param(self, client):
+        route = respx.get("http://test-comfyui:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"png-bytes",
+                headers={"content-type": "image/png"},
+            )
+        )
+        await client.get_image("out.png")
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert "preview" not in params
+
+    @respx.mock
     async def test_delete_queue_item(self, client):
         respx.post("http://test-comfyui:8188/queue").mock(return_value=httpx.Response(200, json={}))
         await client.delete_queue_item("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -192,6 +192,43 @@ class TestComfyUIClient:
         assert result["name"] == "uploaded.png"
 
     @respx.mock
+    async def test_upload_image_default_type(self, client):
+        # Default behavior: form does not include 'type' or 'overwrite' fields
+        route = respx.post("http://test-comfyui:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "input"}
+            )
+        )
+        await client.upload_image(b"data", "x.png")
+        body = route.calls.last.request.content
+        # multipart form encoded — check that type/overwrite are NOT present
+        assert b'name="type"' not in body
+        assert b'name="overwrite"' not in body
+
+    @respx.mock
+    async def test_upload_image_with_type_and_overwrite(self, client):
+        route = respx.post("http://test-comfyui:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "output"}
+            )
+        )
+        await client.upload_image(
+            b"data",
+            "x.png",
+            destination="output",
+            overwrite=True,
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' in body
+        assert b"output" in body
+        assert b'name="overwrite"' in body
+        assert b"true" in body
+
+    async def test_upload_image_rejects_invalid_destination(self, client):
+        with pytest.raises(ValueError, match="destination"):
+            await client.upload_image(b"data", "x.png", destination="garbage")
+
+    @respx.mock
     async def test_get_image(self, client):
         route = respx.get("http://test-comfyui:8188/view").mock(
             return_value=httpx.Response(

--- a/tests/test_tools_files.py
+++ b/tests/test_tools_files.py
@@ -114,6 +114,67 @@ class TestUploadImage:
             await tools["comfyui_upload_image"](filename="malicious.py", image_data=image_b64)
 
 
+class TestUploadImageDestination:
+    @respx.mock
+    async def test_upload_to_output_dir(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "output"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_upload_image"](
+            filename="x.png",
+            image_data="ZGF0YQ==",  # base64 "data"
+            destination="output",
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' in body
+        assert b"output" in body
+        assert "Uploaded" in result
+
+    @respx.mock
+    async def test_upload_with_overwrite(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "input"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        await tools["comfyui_upload_image"](
+            filename="x.png",
+            image_data="ZGF0YQ==",
+            overwrite=True,
+        )
+        body = route.calls.last.request.content
+        assert b'name="overwrite"' in body
+        assert b"true" in body
+
+    @respx.mock
+    async def test_upload_default_unchanged(self, components):
+        # Verify existing default-call behavior is byte-identical to before:
+        # no 'type' or 'overwrite' fields in the multipart body.
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "input"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        await tools["comfyui_upload_image"](
+            filename="x.png",
+            image_data="ZGF0YQ==",
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' not in body
+        assert b'name="overwrite"' not in body
+
+
 class TestGetImage:
     @respx.mock
     async def test_get_image_returns_base64(self, components):

--- a/tests/test_tools_files.py
+++ b/tests/test_tools_files.py
@@ -236,6 +236,73 @@ class TestGetImage:
             await tools["comfyui_get_image"](filename="../../../etc/shadow.png")
 
 
+class TestGetImagePreview:
+    @respx.mock
+    async def test_data_uri_with_webp_preview(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"webp-bytes",
+                headers={"content-type": "image/webp"},
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_get_image"](
+            filename="out.png",
+            preview_format="webp",
+            preview_quality=85,
+        )
+        assert result.startswith("data:image/webp;base64,")
+
+    @respx.mock
+    async def test_data_uri_with_jpeg_preview(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.get("http://test:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"jpeg-bytes",
+                headers={"content-type": "image/jpeg"},
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        await tools["comfyui_get_image"](
+            filename="out.png",
+            preview_format="jpeg",
+            preview_quality=50,
+        )
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["preview"] == "jpeg;50"
+
+    async def test_quality_without_format_rejected(self, components):
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        with pytest.raises(ValueError, match="preview_format"):
+            await tools["comfyui_get_image"](
+                filename="out.png",
+                preview_quality=85,
+            )
+
+    async def test_url_format_ignores_preview(self, components):
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        # When response_format='url', preview params should be ignored
+        # (the returned /view URL is unchanged; LLMs that want a thumbnail
+        # should use response_format='data_uri').
+        result = await tools["comfyui_get_image"](
+            filename="out.png",
+            response_format="url",
+            preview_format="webp",
+            preview_quality=80,
+        )
+        assert "/view?" in result
+        assert "preview" not in result
+
+
 class TestExtractPngMetadata:
     def test_extracts_text_chunks(self):
         workflow = json.dumps({"1": {"class_type": "KSampler", "inputs": {}}})


### PR DESCRIPTION
## Summary

Adopt three deferred ComfyUI upstream-API capabilities in one PR. All three additions are **optional, keyword-only kwargs with defaults that preserve byte-identical legacy behavior** — no breaking changes.

### Changes

- **`/view?preview=<spec>` thumbnails.** `client.get_image` gains a `preview` kwarg; `comfyui_get_image` exposes `preview_format` (`Literal["webp", "jpeg"]`) and `preview_quality` (1-100). With `response_format="data_uri"`, ComfyUI re-encodes the image server-side — sending a 90 KB webp instead of a multi-MB PNG is a real bandwidth and context-window win for LLM clients.
- **`/upload/image` destination + overwrite.** `client.upload_image` and `comfyui_upload_image` gain `destination` (`Literal["input", "output", "temp"]`, default `input`) and `overwrite` (bool, default `False`). The Literal restricts callers to safe destinations. Defense-in-depth: pydantic validates the enum at the FastMCP boundary AND the client layer has its own `if destination not in {...}: raise ValueError` runtime check. Sanitizer validation (filename, subfolder, size) still applies on every path.
- **`/history?offset=N`.** `client.get_history` gains an optional `offset` kwarg. The `comfyui_get_history` tool is intentionally unchanged in this PR — server-side paging would change the meaning of the pagination envelope's `total` field and needs separate design.

### Default-behavior guarantees

Three explicit regression tests lock in byte-identical behavior when the new kwargs are not passed:
- `test_get_image_without_preview_omits_param` — `/view` URL has no `preview` query param
- `test_upload_default_unchanged` — `/upload/image` form body has no `type` or `overwrite` fields
- `test_get_history_without_offset_omits_param` — `/history` URL has no `offset` query param

## Test Plan

- [x] `uv run pytest` — 512 passed (+16 new tests over main's 496)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/comfyui_mcp/` — no issues
- [x] `tests/test_security_invariants.py` confirms sanitizer + audit + rate limiter still in `comfyui_upload_image` closure
- [x] Tool count unchanged (45 `@mcp.tool` decorators) — this PR adds optional params, not new tools
- [ ] Smoke test against a live ComfyUI: `comfyui_get_image(filename="...", preview_format="webp", preview_quality=85)` returns smaller webp; `comfyui_upload_image(..., destination="output")` writes to output dir; client.get_history(max_items=100, offset=100) works

## Out of scope

- Wiring `comfyui_get_history` to use server-side offset (separate design — `total` field semantics).
- `comfyui_upload_mask` symmetric `destination`/`overwrite` params (deferred).
- `comfyui_list_nodes` filtering by new object_info fields (`deprecated`, `experimental`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)