### PR TITLE
Housekeeping: lockfile sync, plan archive, gitignore tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ htmlcov/
 
 # Review artifacts
 .full-review/
-.full-review/
+
+# Skill output (graphify knowledge graph artifacts)
+graphify-out/

--- a/docs/superpowers/plans/2026-05-10-jobs-api-and-targeted-interrupt.md
+++ b/docs/superpowers/plans/2026-05-10-jobs-api-and-targeted-interrupt.md
@@ -1,0 +1,726 @@
+# Unified Jobs API + Targeted Interrupt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire two upstream ComfyUI improvements into the MCP. (1) Use the unified `/api/jobs` and `/api/jobs/{job_id}` endpoints to fix the existing `comfyui_get_job` tool (which today only sees completed jobs because it calls `/history/{prompt_id}`) and add a new `comfyui_list_jobs` tool with status/sort/pagination. (2) Extend `POST /interrupt` and the `comfyui_interrupt` tool to accept an optional `prompt_id` so callers can target a specific running prompt instead of always doing a global interrupt.
+
+**Architecture:** Three new client methods (`get_job`, `get_jobs`, an extended `interrupt`) follow the existing `client.py` patterns: validate input up front (UUID for IDs, allowlist for sort/status), call `self._request(...)`, parse JSON. Tool layer changes follow CLAUDE.md rules — every tool calls `limiter.check()` and `audit.async_log()` first, returns `dict[str, Any]` for structured responses, uses `Annotated[type, Field(...)]` for parameters with constraints. The response shape of `comfyui_get_job` changes (was `{prompt_id: {...}}`, now the bare job object) — this is a deliberate fix because the old shape was already broken for queued/running jobs.
+
+**Tech Stack:** Python 3.12, httpx (async), respx (HTTP mocking), pytest with `asyncio_mode = auto`, FastMCP, Pydantic `Field`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/comfyui_mcp/client.py` — add `get_job`, `get_jobs`; extend `interrupt`
+- `src/comfyui_mcp/tools/jobs.py` — change `comfyui_get_job` body, add `comfyui_list_jobs`, extend `comfyui_interrupt`
+- `tests/test_client.py` — tests for new client methods
+- `tests/test_tools_jobs.py` — update `TestGetJob`, `TestInterrupt`; add `TestListJobs`
+- `README.md` — tool table updates
+
+No new files. The new tool fits in `tools/jobs.py` since it's a job-management read.
+
+---
+
+## Task 1: Client `get_job(job_id)` method
+
+**Files:**
+- Modify: `src/comfyui_mcp/client.py` (add method near line 167, after `get_history_item`)
+- Test: `tests/test_client.py` (add to `TestComfyUIClient` class)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_client.py` inside `class TestComfyUIClient:` (after `test_get_history` around line 56):
+
+```python
+    @respx.mock
+    async def test_get_job_returns_job_object(self, client):
+        job_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        respx.get(f"http://test-comfyui:8188/api/jobs/{job_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "prompt_id": job_id,
+                    "status": "in_progress",
+                    "outputs": {},
+                },
+            )
+        )
+        result = await client.get_job(job_id)
+        assert result["prompt_id"] == job_id
+        assert result["status"] == "in_progress"
+
+    async def test_get_job_rejects_non_uuid(self, client):
+        with pytest.raises(ValueError, match="Invalid prompt_id"):
+            await client.get_job("not-a-uuid")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_client.py::TestComfyUIClient::test_get_job_returns_job_object tests/test_client.py::TestComfyUIClient::test_get_job_rejects_non_uuid -v`
+Expected: both FAIL with `AttributeError: 'ComfyUIClient' object has no attribute 'get_job'`
+
+- [ ] **Step 3: Implement the method**
+
+Add to `src/comfyui_mcp/client.py` immediately after `get_history_item` (around line 167):
+
+```python
+    async def get_job(self, job_id: str) -> dict:
+        """GET /api/jobs/{job_id} — unified job lookup across queue + history."""
+        _validate_prompt_id(job_id)
+        r = await self._request("get", f"/api/jobs/{job_id}")
+        return r.json()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_client.py::TestComfyUIClient::test_get_job_returns_job_object tests/test_client.py::TestComfyUIClient::test_get_job_rejects_non_uuid -v`
+Expected: both PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/comfyui_mcp/client.py tests/test_client.py
+git commit -m "Add ComfyUIClient.get_job for /api/jobs/{job_id}"
+```
+
+---
+
+## Task 2: Client `get_jobs(...)` method
+
+**Files:**
+- Modify: `src/comfyui_mcp/client.py` (add method right after `get_job`)
+- Test: `tests/test_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_client.py` inside `class TestComfyUIClient:`:
+
+```python
+    @respx.mock
+    async def test_get_jobs_no_params(self, client):
+        respx.get("http://test-comfyui:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={"jobs": [], "pagination": {"offset": 0, "limit": None, "total": 0, "has_more": False}},
+            )
+        )
+        result = await client.get_jobs()
+        assert "jobs" in result
+        assert "pagination" in result
+
+    @respx.mock
+    async def test_get_jobs_passes_filters(self, client):
+        route = respx.get("http://test-comfyui:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200, json={"jobs": [], "pagination": {"offset": 5, "limit": 10, "total": 0, "has_more": False}}
+            )
+        )
+        await client.get_jobs(
+            status=["pending", "in_progress"],
+            workflow_id="wf-123",
+            sort_by="execution_duration",
+            sort_order="asc",
+            limit=10,
+            offset=5,
+        )
+        request = route.calls.last.request
+        params = dict(request.url.params.multi_items())
+        assert params["status"] == "pending,in_progress"
+        assert params["workflow_id"] == "wf-123"
+        assert params["sort_by"] == "execution_duration"
+        assert params["sort_order"] == "asc"
+        assert params["limit"] == "10"
+        assert params["offset"] == "5"
+
+    async def test_get_jobs_rejects_invalid_status(self, client):
+        with pytest.raises(ValueError, match="Invalid status"):
+            await client.get_jobs(status=["bogus"])
+
+    async def test_get_jobs_rejects_invalid_sort_by(self, client):
+        with pytest.raises(ValueError, match="sort_by"):
+            await client.get_jobs(sort_by="random")
+
+    async def test_get_jobs_rejects_invalid_sort_order(self, client):
+        with pytest.raises(ValueError, match="sort_order"):
+            await client.get_jobs(sort_order="sideways")
+
+    async def test_get_jobs_rejects_negative_limit(self, client):
+        with pytest.raises(ValueError, match="limit"):
+            await client.get_jobs(limit=0)
+
+    async def test_get_jobs_rejects_negative_offset(self, client):
+        with pytest.raises(ValueError, match="offset"):
+            await client.get_jobs(offset=-1)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_client.py -v -k "get_jobs"`
+Expected: all FAIL with `AttributeError: ... 'get_jobs'`
+
+- [ ] **Step 3: Add validation constants and the method**
+
+Edit `src/comfyui_mcp/client.py`. Add module-level constants near the top (after `_SAFE_SEGMENT_RE` around line 18):
+
+```python
+_VALID_JOB_STATUSES = frozenset({"pending", "in_progress", "completed", "failed"})
+_VALID_JOB_SORT_BY = frozenset({"created_at", "execution_duration"})
+_VALID_JOB_SORT_ORDER = frozenset({"asc", "desc"})
+```
+
+Add the method to `ComfyUIClient` immediately after `get_job`:
+
+```python
+    async def get_jobs(
+        self,
+        *,
+        status: list[str] | None = None,
+        workflow_id: str | None = None,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
+        """GET /api/jobs — unified, paginated, filterable job list."""
+        if status is not None:
+            invalid = [s for s in status if s not in _VALID_JOB_STATUSES]
+            if invalid:
+                raise ValueError(
+                    f"Invalid status value(s): {invalid}. "
+                    f"Valid: {sorted(_VALID_JOB_STATUSES)}"
+                )
+        if sort_by not in _VALID_JOB_SORT_BY:
+            raise ValueError(
+                f"sort_by must be one of {sorted(_VALID_JOB_SORT_BY)}, got {sort_by!r}"
+            )
+        if sort_order not in _VALID_JOB_SORT_ORDER:
+            raise ValueError(
+                f"sort_order must be one of {sorted(_VALID_JOB_SORT_ORDER)}, got {sort_order!r}"
+            )
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+
+        params: dict[str, str] = {
+            "sort_by": sort_by,
+            "sort_order": sort_order,
+            "offset": str(offset),
+        }
+        if status:
+            params["status"] = ",".join(status)
+        if workflow_id:
+            params["workflow_id"] = workflow_id
+        if limit is not None:
+            params["limit"] = str(limit)
+
+        r = await self._request("get", "/api/jobs", params=params)
+        return r.json()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_client.py -v -k "get_jobs"`
+Expected: all 7 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/comfyui_mcp/client.py tests/test_client.py
+git commit -m "Add ComfyUIClient.get_jobs for paginated /api/jobs"
+```
+
+---
+
+## Task 3: Extend `ComfyUIClient.interrupt` to accept optional `prompt_id`
+
+**Files:**
+- Modify: `src/comfyui_mcp/client.py:169-170` (the `interrupt` method)
+- Test: `tests/test_client.py` (add to `TestComfyUIClient`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_client.py` inside `class TestComfyUIClient:`:
+
+```python
+    @respx.mock
+    async def test_interrupt_with_prompt_id_sends_body(self, client):
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        route = respx.post("http://test-comfyui:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        await client.interrupt(prompt_id=prompt_id)
+        request = route.calls.last.request
+        body = json.loads(request.content)
+        assert body == {"prompt_id": prompt_id}
+
+    @respx.mock
+    async def test_interrupt_without_prompt_id_sends_no_body(self, client):
+        route = respx.post("http://test-comfyui:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        await client.interrupt()
+        request = route.calls.last.request
+        # Either no body or empty body — definitely no prompt_id
+        assert request.content in (b"", b"{}", None)
+
+    async def test_interrupt_rejects_non_uuid_prompt_id(self, client):
+        with pytest.raises(ValueError, match="Invalid prompt_id"):
+            await client.interrupt(prompt_id="not-a-uuid")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_client.py -v -k "interrupt"`
+Expected: 2 new tests FAIL (`test_interrupt_with_prompt_id_sends_body`, `test_interrupt_rejects_non_uuid_prompt_id`); existing `test_interrupt` and the new `test_interrupt_without_prompt_id_sends_no_body` PASS.
+
+- [ ] **Step 3: Update the method**
+
+In `src/comfyui_mcp/client.py`, replace the existing `interrupt` method:
+
+```python
+    async def interrupt(self, prompt_id: str | None = None) -> None:
+        """POST /interrupt — global interrupt, or targeted if prompt_id is given.
+
+        Without prompt_id, interrupts whatever is currently executing.
+        With prompt_id, ComfyUI only interrupts if that prompt is the running one;
+        otherwise the call is a no-op (server returns 200 either way).
+        """
+        if prompt_id is not None:
+            _validate_prompt_id(prompt_id)
+            await self._request("post", "/interrupt", json={"prompt_id": prompt_id})
+        else:
+            await self._request("post", "/interrupt")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_client.py -v -k "interrupt"`
+Expected: all 4 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/comfyui_mcp/client.py tests/test_client.py
+git commit -m "Allow targeted interrupt via optional prompt_id"
+```
+
+---
+
+## Task 4: Migrate `comfyui_get_job` tool to `/api/jobs/{job_id}`
+
+This task **changes the response shape** of `comfyui_get_job`. The old shape was `{prompt_id: {<execution_data>}}` (envelope keyed by prompt_id, returning empty `{}` for queued/running). The new shape is the bare job object including queued/running jobs. The existing tool was effectively broken for non-history jobs, so this is a fix.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/jobs.py:53-60`
+- Test: `tests/test_tools_jobs.py:70-83` (the `TestGetJob` class)
+
+- [ ] **Step 1: Update the failing test to the new shape**
+
+Replace `class TestGetJob` in `tests/test_tools_jobs.py` (lines 70-83) with:
+
+```python
+class TestGetJob:
+    @respx.mock
+    async def test_get_job_returns_unified_job_object(self, components):
+        client, audit, limiter = components
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "prompt_id": prompt_id,
+                    "status": "in_progress",
+                    "outputs": {},
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_get_job"](prompt_id=prompt_id)
+        assert result["prompt_id"] == prompt_id
+        assert result["status"] == "in_progress"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_tools_jobs.py::TestGetJob -v`
+Expected: FAIL — the tool currently calls `/history/{prompt_id}`, not `/api/jobs/{prompt_id}`, so the respx mock isn't matched and the call 404s (or hits an unmocked URL).
+
+- [ ] **Step 3: Update the tool**
+
+In `src/comfyui_mcp/tools/jobs.py`, replace the body of `comfyui_get_job` (around line 53-58):
+
+```python
+    async def comfyui_get_job(prompt_id: str) -> dict[str, Any]:
+        """Look up a single job by prompt_id across queue + history.
+
+        Returns the unified job object: status (pending/in_progress/completed/failed),
+        timing, outputs, etc. Use this to check on a job that may be queued, running,
+        or already finished.
+        """
+        rl = read_limiter if read_limiter is not None else limiter
+        rl.check("get_job")
+        await audit.async_log(tool="get_job", action="called", extra={"prompt_id": prompt_id})
+        return await client.get_job(prompt_id)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_tools_jobs.py::TestGetJob -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full jobs test file to catch regressions**
+
+Run: `uv run pytest tests/test_tools_jobs.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/jobs.py tests/test_tools_jobs.py
+git commit -m "Migrate comfyui_get_job to unified /api/jobs/{job_id}"
+```
+
+---
+
+## Task 5: Add `comfyui_list_jobs` tool
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/jobs.py` (add tool, register in `tool_fns`)
+- Test: `tests/test_tools_jobs.py` (new `TestListJobs` class)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_tools_jobs.py` after the existing `TestGetJob` class:
+
+```python
+class TestListJobs:
+    @respx.mock
+    async def test_list_jobs_default(self, components):
+        client, audit, limiter = components
+        respx.get("http://test:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [{"prompt_id": "abc", "status": "completed"}],
+                    "pagination": {"offset": 0, "limit": None, "total": 1, "has_more": False},
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_list_jobs"]()
+        assert "jobs" in result
+        assert "pagination" in result
+        assert result["jobs"][0]["status"] == "completed"
+
+    @respx.mock
+    async def test_list_jobs_passes_filters(self, components):
+        client, audit, limiter = components
+        route = respx.get("http://test:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={"jobs": [], "pagination": {"offset": 0, "limit": 5, "total": 0, "has_more": False}},
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        await tools["comfyui_list_jobs"](
+            status=["pending", "in_progress"],
+            sort_by="execution_duration",
+            sort_order="asc",
+            limit=5,
+            offset=0,
+        )
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["status"] == "pending,in_progress"
+        assert params["sort_by"] == "execution_duration"
+        assert params["sort_order"] == "asc"
+        assert params["limit"] == "5"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_tools_jobs.py::TestListJobs -v`
+Expected: FAIL with `KeyError: 'comfyui_list_jobs'`
+
+- [ ] **Step 3: Add the tool**
+
+In `src/comfyui_mcp/tools/jobs.py`:
+
+(a) Update imports at the top of the file (after the existing imports):
+
+```python
+from typing import Annotated, Any, Literal
+
+from pydantic import Field
+```
+
+Note: `Any` is already imported; replace the existing `from typing import Any` line with `from typing import Annotated, Any, Literal`.
+
+(b) Insert the new tool inside `register_job_tools`, immediately after `comfyui_get_job` is registered (after the line `tool_fns["comfyui_get_job"] = comfyui_get_job`):
+
+```python
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )
+    async def comfyui_list_jobs(
+        status: Annotated[
+            list[Literal["pending", "in_progress", "completed", "failed"]] | None,
+            Field(
+                default=None,
+                description="Filter by job status (any combination).",
+            ),
+        ] = None,
+        workflow_id: Annotated[
+            str | None,
+            Field(default=None, description="Filter by workflow ID set in extra_data."),
+        ] = None,
+        sort_by: Annotated[
+            Literal["created_at", "execution_duration"],
+            Field(default="created_at", description="Sort field."),
+        ] = "created_at",
+        sort_order: Annotated[
+            Literal["asc", "desc"],
+            Field(default="desc", description="Sort direction."),
+        ] = "desc",
+        limit: Annotated[
+            int | None,
+            Field(default=None, ge=1, le=1000, description="Max jobs to return."),
+        ] = None,
+        offset: Annotated[
+            int,
+            Field(default=0, ge=0, description="Jobs to skip for pagination."),
+        ] = 0,
+    ) -> dict[str, Any]:
+        """List jobs across queue and history with filtering, sorting, and pagination.
+
+        Returns {"jobs": [...], "pagination": {"offset", "limit", "total", "has_more"}}.
+        Each job includes prompt_id, status (pending/in_progress/completed/failed),
+        timing, and outputs (when completed).
+        """
+        rl = read_limiter if read_limiter is not None else limiter
+        rl.check("list_jobs")
+        await audit.async_log(
+            tool="list_jobs",
+            action="called",
+            extra={
+                "status": status,
+                "workflow_id": workflow_id,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        return await client.get_jobs(
+            status=status,
+            workflow_id=workflow_id,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            limit=limit,
+            offset=offset,
+        )
+
+    tool_fns["comfyui_list_jobs"] = comfyui_list_jobs
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_tools_jobs.py::TestListJobs -v`
+Expected: both PASS
+
+- [ ] **Step 5: Verify security invariants still hold**
+
+Run: `uv run pytest tests/test_security_invariants.py -v`
+Expected: PASS — `comfyui_list_jobs` closure captures `audit`, `limiter`/`read_limiter`, `client`, satisfying rate-limit and audit invariants.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/jobs.py tests/test_tools_jobs.py
+git commit -m "Add comfyui_list_jobs tool for paginated unified job listing"
+```
+
+---
+
+## Task 6: Extend `comfyui_interrupt` tool with optional `prompt_id`
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/jobs.py:87-92`
+- Test: `tests/test_tools_jobs.py:57-67` (`TestInterrupt`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `class TestInterrupt` in `tests/test_tools_jobs.py` (lines 57-67) with:
+
+```python
+class TestInterrupt:
+    @respx.mock
+    async def test_interrupt_global(self, components):
+        client, audit, limiter = components
+        route = respx.post("http://test:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_interrupt"]()
+        assert route.called
+        body = route.calls.last.request.content
+        # No prompt_id sent → no body, or empty
+        assert body in (b"", b"{}", None)
+        assert "current" in result.lower() or "global" in result.lower()
+
+    @respx.mock
+    async def test_interrupt_targeted(self, components):
+        import json as _json
+        client, audit, limiter = components
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        route = respx.post("http://test:8188/interrupt").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_interrupt"](prompt_id=prompt_id)
+        assert route.called
+        body = _json.loads(route.calls.last.request.content)
+        assert body == {"prompt_id": prompt_id}
+        assert prompt_id in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_tools_jobs.py::TestInterrupt -v`
+Expected: `test_interrupt_targeted` FAILS (`comfyui_interrupt` doesn't accept `prompt_id`); `test_interrupt_global` may pass or fail depending on the assertion change.
+
+- [ ] **Step 3: Update the tool**
+
+Replace `comfyui_interrupt` in `src/comfyui_mcp/tools/jobs.py` (around lines 79-94):
+
+```python
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=False,
+            destructiveHint=True,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )
+    async def comfyui_interrupt(prompt_id: str | None = None) -> str:
+        """Interrupt the currently executing workflow.
+
+        Without prompt_id: global interrupt — stops whatever is running now.
+        With prompt_id: targeted — only interrupts if that prompt is the
+        running one. ComfyUI silently no-ops if prompt_id is queued but
+        not yet running.
+        """
+        limiter.check("interrupt")
+        await audit.async_log(
+            tool="interrupt", action="called", extra={"prompt_id": prompt_id}
+        )
+        await client.interrupt(prompt_id=prompt_id)
+        if prompt_id is None:
+            return "Interrupted current execution (global)"
+        return f"Requested interrupt for prompt {prompt_id} (no-op if not running)"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_tools_jobs.py::TestInterrupt -v`
+Expected: both PASS
+
+- [ ] **Step 5: Run the full jobs test file**
+
+Run: `uv run pytest tests/test_tools_jobs.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/jobs.py tests/test_tools_jobs.py
+git commit -m "Allow targeted interrupt via optional prompt_id in comfyui_interrupt"
+```
+
+---
+
+## Task 7: README updates
+
+**Files:**
+- Modify: `README.md:227-237` (Job Management table)
+
+- [ ] **Step 1: Update the Job Management table**
+
+In `README.md`, replace lines 232 and 234 and insert a new row for `comfyui_list_jobs`:
+
+Before:
+```markdown
+| `comfyui_get_queue` | Get current execution queue state. |
+| `comfyui_get_job` | Check status of a job by prompt_id. |
+| `comfyui_cancel_job` | Cancel a running or queued job. |
+| `comfyui_interrupt` | Interrupt the currently executing workflow. |
+```
+
+After:
+```markdown
+| `comfyui_get_queue` | Get current execution queue state. |
+| `comfyui_list_jobs` | List jobs across queue + history with status filter, sorting, and pagination. |
+| `comfyui_get_job` | Look up a single job (queued/running/finished) by prompt_id. |
+| `comfyui_cancel_job` | Cancel a running or queued job. |
+| `comfyui_interrupt` | Interrupt the running workflow (global, or targeted via optional prompt_id). |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "Document comfyui_list_jobs and targeted interrupt"
+```
+
+---
+
+## Task 8: Final verification sweep
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest -v`
+Expected: ALL PASS (no skipped, no errors).
+
+- [ ] **Step 2: Run the linter**
+
+Run: `uv run ruff check src/ tests/`
+Expected: no diagnostics.
+
+- [ ] **Step 3: Run the formatter check**
+
+Run: `uv run ruff format --check src/ tests/`
+Expected: no diff. If it fails, run `uv run ruff format src/ tests/` and amend the relevant commit (or add a follow-up format commit).
+
+- [ ] **Step 4: Run the type checker**
+
+Run: `uv run mypy src/comfyui_mcp/`
+Expected: 0 errors.
+
+- [ ] **Step 5: Run pre-commit hooks**
+
+Run: `uv run pre-commit run --all-files`
+Expected: all hooks pass.
+
+If any of the above fail, fix and amend the appropriate commit (or add a fixup commit) before declaring the plan complete.
+
+---
+
+## Out of scope (deliberately not in this plan)
+
+- `/history?offset=N` pagination — separate, smaller change.
+- `/view?preview=...` server-side thumbnails — separate plan; affects `tools/files.py`.
+- `/upload/image` `type` and `overwrite` params — separate; raises security surface.
+- Surfacing new `object_info` fields (`deprecated`, `experimental`, etc.) in `list_nodes` — separate.
+- `partial_execution_targets` on `POST /prompt` — niche, separate.

--- a/docs/superpowers/plans/2026-05-10-mcp-best-practices-cleanup.md
+++ b/docs/superpowers/plans/2026-05-10-mcp-best-practices-cleanup.md
@@ -1,0 +1,1110 @@
+# MCP Best-Practices Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address the actionable findings from a best-practices audit of the comfyui_mcp tool surface. Six concrete drift items across pagination, parameter schemas, parameter naming, and docstrings that close gaps with MCP guidance and CLAUDE.md project rules.
+
+**Architecture:** Surgical fixes in the tool layer (`src/comfyui_mcp/tools/*.py`) plus one shared addition to `pagination.py` for reusable `LimitField` / `OffsetField` type aliases. No client-layer or security-layer changes. Two parameter renames (`id` → `node_id`, `format` → `output_format`) are deliberate breaking changes for MCP callers — documented in the relevant commit messages.
+
+**Tech Stack:** Python 3.12, FastMCP, Pydantic `Field`/`Annotated`, pytest with `asyncio_mode = auto`, respx for HTTP mocking.
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/comfyui_mcp/pagination.py` — add `LimitField`, `OffsetField` `Annotated` type aliases.
+- `src/comfyui_mcp/tools/history.py` — bump cap, use shared fields.
+- `src/comfyui_mcp/tools/discovery.py` — paginate three holdout list tools, use shared fields, beef up stub docstrings.
+- `src/comfyui_mcp/tools/files.py` — use shared fields on `list_outputs`.
+- `src/comfyui_mcp/tools/nodes.py` — rename `id` → `node_id`, add Field constraints, use shared fields on `search_custom_nodes`.
+- `src/comfyui_mcp/tools/generation.py` — rename `format` → `output_format`, use `Literal`.
+- `src/comfyui_mcp/tools/workflow.py` — fix `validate_workflow` docstring.
+- `tests/test_tools_discovery.py` — update tests for newly-paginated tools.
+- `tests/test_tools_nodes.py` — update tests for `node_id` rename.
+- `tests/test_tools_generation.py` — update tests for `output_format` rename.
+- `tests/test_pagination.py` — add tests for new field aliases.
+- `tests/test_tools_history.py` — confirm new cap behavior.
+- `README.md` — flag the breaking parameter renames.
+
+No new files except the in-place `pagination.py` additions.
+
+---
+
+## Task 1: Fix `comfyui_get_history` pagination cap
+
+The tool internally caps `max_items=100` then paginates the result. The `total` reported is the size of the cap, not the true history count. Fix by bumping to 1000 (the client's hard cap from `client.get_history`'s `min(max_items, 1000)`) and documenting the cap.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/history.py:42` (and docstring at lines 34-39)
+- Test: `tests/test_tools_history.py`
+
+- [ ] **Step 1: Read existing test file to confirm patterns**
+
+Run: `cat tests/test_tools_history.py`
+
+Note the existing test layout, fixture name, and import style — mirror them in step 2.
+
+- [ ] **Step 2: Write a failing test for the bumped cap**
+
+Add to `tests/test_tools_history.py` inside the existing test class (or at module level if no class):
+
+```python
+    @respx.mock
+    async def test_get_history_passes_1000_cap_to_client(self, components):
+        client, audit, limiter = components
+        # The tool should request up to 1000 history items from the client
+        # so that pagination can report a meaningful `total` for callers paging
+        # through history.
+        route = respx.get("http://test:8188/history").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_history_tools(mcp, client, audit, limiter)
+        await tools["comfyui_get_history"]()
+        request = route.calls.last.request
+        params = dict(request.url.params.multi_items())
+        assert params.get("max_items") == "1000"
+```
+
+If the existing test file uses a different fixture or import pattern (e.g. `mcp = FastMCP("test")` is already wrapped in a helper), match that.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_tools_history.py::test_get_history_passes_1000_cap_to_client -v` (use the right test path/class — adjust based on the existing file's structure)
+Expected: FAIL — currently the request will have `max_items=100`.
+
+- [ ] **Step 4: Update the tool**
+
+In `src/comfyui_mcp/tools/history.py`, change line 42 from:
+
+```python
+        raw = await client.get_history(max_items=100)
+```
+
+to:
+
+```python
+        raw = await client.get_history(max_items=1000)
+```
+
+And update the docstring (lines 34-39) to:
+
+```python
+        """Browse ComfyUI execution history (read-only).
+
+        Covers up to the 1000 most recent history entries — older entries are
+        unreachable. Pagination operates over that window.
+
+        Args:
+            limit: Maximum number of results to return (default: 25, max: 100)
+            offset: Starting index for pagination (default: 0)
+        """
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_tools_history.py -v`
+Expected: all PASS, including pre-existing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/history.py tests/test_tools_history.py
+git commit -m "Bump get_history internal cap from 100 to 1000 to fix pagination total"
+```
+
+---
+
+## Task 2: Fix `comfyui_validate_workflow` docstring
+
+The docstring says it returns a JSON string; the function actually returns a `dict[str, Any]`. One-line edit.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/workflow.py:183-185`
+
+- [ ] **Step 1: Apply the docstring fix**
+
+In `src/comfyui_mcp/tools/workflow.py`, replace lines 183-185:
+
+```python
+        Returns:
+            JSON string with: valid (bool), errors (list), warnings (list),
+            node_count (int), pipeline (str).
+        """
+```
+
+with:
+
+```python
+        Returns:
+            Dict with keys: valid (bool), errors (list), warnings (list),
+            node_count (int), pipeline (str).
+        """
+```
+
+- [ ] **Step 2: Run existing tests to confirm no regression**
+
+Run: `uv run pytest tests/test_tools_workflow.py -v`
+Expected: all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/workflow.py
+git commit -m "Fix validate_workflow docstring: returns dict, not JSON string"
+```
+
+---
+
+## Task 3: Add `LimitField` / `OffsetField` type aliases
+
+Promote the standard pagination params to reusable `Annotated[int, Field(...)]` aliases so list tools can declare schema constraints in one line. Keep the existing `paginate(...)` runtime helper unchanged.
+
+**Files:**
+- Modify: `src/comfyui_mcp/pagination.py` (add new aliases)
+- Test: `tests/test_pagination.py`
+
+- [ ] **Step 1: Write a failing test for the new aliases**
+
+Add to `tests/test_pagination.py`:
+
+```python
+def test_limit_field_default_and_bounds():
+    from typing import get_type_hints
+
+    from pydantic import BaseModel
+
+    from comfyui_mcp.pagination import LimitField, OffsetField
+
+    class _Model(BaseModel):
+        limit: LimitField = 25
+        offset: OffsetField = 0
+
+    schema = _Model.model_json_schema()
+    assert schema["properties"]["limit"]["minimum"] == 1
+    assert schema["properties"]["limit"]["maximum"] == 100
+    assert schema["properties"]["offset"]["minimum"] == 0
+    # Description present
+    assert "results" in schema["properties"]["limit"]["description"].lower()
+    assert "pagination" in schema["properties"]["offset"]["description"].lower()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_pagination.py::test_limit_field_default_and_bounds -v`
+Expected: FAIL with `ImportError: cannot import name 'LimitField' from 'comfyui_mcp.pagination'`.
+
+- [ ] **Step 3: Add the aliases**
+
+Append to `src/comfyui_mcp/pagination.py`:
+
+```python
+from typing import Annotated  # noqa: E402
+
+from pydantic import Field  # noqa: E402
+
+LimitField = Annotated[
+    int,
+    Field(
+        ge=1,
+        le=100,
+        description="Maximum number of results to return (1-100, default varies by tool).",
+    ),
+]
+
+OffsetField = Annotated[
+    int,
+    Field(
+        ge=0,
+        description="Zero-based starting index for pagination.",
+    ),
+]
+```
+
+(The `# noqa: E402` annotations are because these new imports come after the existing `paginate` function — ruff would otherwise flag module-level imports below code. If the existing import block is at the top of the file with no code in between, omit the `# noqa` markers and put the imports there instead.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_pagination.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint and format**
+
+Run: `uv run ruff check src/comfyui_mcp/pagination.py && uv run ruff format src/comfyui_mcp/pagination.py && uv run mypy src/comfyui_mcp/pagination.py`
+Expected: clean. If ruff complains about import order, move the imports to the top of the file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/comfyui_mcp/pagination.py tests/test_pagination.py
+git commit -m "Add LimitField and OffsetField shared pagination type aliases"
+```
+
+---
+
+## Task 4: Apply `LimitField` / `OffsetField` to existing paginated tools
+
+Update list tools that currently take bare `limit: int = 25, offset: int = 0` to use the shared aliases so MCP schemas advertise the `ge`/`le` constraints. Tools with non-default bounds (e.g., `search_custom_nodes` max=25) keep inline `Field` since their bounds differ.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/history.py:33`
+- Modify: `src/comfyui_mcp/tools/discovery.py:170-171, 196`
+- Modify: `src/comfyui_mcp/tools/files.py:207`
+
+- [ ] **Step 1: Update `comfyui_get_history`**
+
+In `src/comfyui_mcp/tools/history.py`, replace the existing import block at the top with (preserving existing imports):
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.pagination import LimitField, OffsetField, paginate
+from comfyui_mcp.security.rate_limit import RateLimiter
+```
+
+Replace the function signature on line 33:
+
+```python
+    async def comfyui_get_history(limit: int = 25, offset: int = 0) -> dict[str, Any]:
+```
+
+with:
+
+```python
+    async def comfyui_get_history(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+```
+
+- [ ] **Step 2: Update `comfyui_list_models` and `comfyui_list_nodes`**
+
+In `src/comfyui_mcp/tools/discovery.py`, add `LimitField, OffsetField` to the existing pagination import:
+
+Find the line:
+
+```python
+from comfyui_mcp.pagination import paginate
+```
+
+Replace with:
+
+```python
+from comfyui_mcp.pagination import LimitField, OffsetField, paginate
+```
+
+Then replace the `comfyui_list_models` signature (lines 170-171 are inside the function definition; the signature spans multiple lines):
+
+```python
+        limit: int = 25,
+        offset: int = 0,
+```
+
+with:
+
+```python
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+```
+
+And `comfyui_list_nodes` line 196:
+
+```python
+    async def comfyui_list_nodes(limit: int = 25, offset: int = 0) -> dict[str, Any]:
+```
+
+with:
+
+```python
+    async def comfyui_list_nodes(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+```
+
+- [ ] **Step 3: Update `comfyui_list_outputs`**
+
+In `src/comfyui_mcp/tools/files.py`, find the existing import:
+
+```python
+from comfyui_mcp.pagination import paginate
+```
+
+Replace with:
+
+```python
+from comfyui_mcp.pagination import LimitField, OffsetField, paginate
+```
+
+Then replace the `comfyui_list_outputs` signature on line 207:
+
+```python
+    async def comfyui_list_outputs(limit: int = 25, offset: int = 0) -> dict[str, Any]:
+```
+
+with:
+
+```python
+    async def comfyui_list_outputs(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+```
+
+- [ ] **Step 4: Run the affected test files**
+
+Run: `uv run pytest tests/test_tools_history.py tests/test_tools_discovery.py tests/test_tools_files.py -v`
+Expected: all PASS — these are pure type-annotation refactors, runtime behavior unchanged.
+
+- [ ] **Step 5: Lint and format**
+
+Run: `uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src/comfyui_mcp/`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/history.py src/comfyui_mcp/tools/discovery.py src/comfyui_mcp/tools/files.py
+git commit -m "Use shared LimitField/OffsetField in paginated list tools"
+```
+
+---
+
+## Task 5: Paginate the holdout list tools
+
+`comfyui_list_extensions`, `comfyui_list_model_folders`, and `comfyui_list_workflows` return bare lists with no pagination. Wrap with `paginate()` so they match the project's contract.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/discovery.py:236-242, 252-258, 284-290`
+- Test: `tests/test_tools_discovery.py:95-106, 123-135`
+
+### Step 1: Update `comfyui_list_extensions`
+
+- [ ] In `src/comfyui_mcp/tools/discovery.py`, replace the body of `comfyui_list_extensions` (lines 252-256):
+
+```python
+    async def comfyui_list_extensions() -> list[Any]:
+        """List available ComfyUI extensions."""
+        limiter.check("list_extensions")
+        await audit.async_log(tool="list_extensions", action="called")
+        return await client.get_extensions()
+```
+
+with:
+
+```python
+    async def comfyui_list_extensions(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+        """List installed ComfyUI extensions (front-end / back-end JavaScript modules
+        registered with the ComfyUI server).
+
+        Returns a paginated envelope: ``{items, total, offset, limit, has_more}``.
+        Each item is the extension's URL/path string.
+        """
+        limiter.check("list_extensions")
+        await audit.async_log(tool="list_extensions", action="called")
+        extensions = await client.get_extensions()
+        return paginate(extensions, offset, limit, default_limit=25, max_limit=100)
+```
+
+### Step 2: Update `comfyui_list_model_folders`
+
+- [ ] Replace the body (lines 284-288):
+
+```python
+    async def comfyui_list_model_folders() -> list[Any]:
+        """List available model folder types (checkpoints, loras, vae, etc.)."""
+        limiter.check("list_model_folders")
+        await audit.async_log(tool="list_model_folders", action="called")
+        return await client.get_model_types()
+```
+
+with:
+
+```python
+    async def comfyui_list_model_folders(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+        """List the model-folder types ComfyUI recognizes (checkpoints, loras, vae,
+        controlnet, etc.). Pass any returned name as the ``folder`` argument to
+        ``comfyui_list_models`` or ``comfyui_get_model_metadata``.
+
+        Returns a paginated envelope: ``{items, total, offset, limit, has_more}``.
+        """
+        limiter.check("list_model_folders")
+        await audit.async_log(tool="list_model_folders", action="called")
+        folders = await client.get_model_types()
+        return paginate(folders, offset, limit, default_limit=25, max_limit=100)
+```
+
+### Step 3: Update `comfyui_list_workflows`
+
+- [ ] Replace the body (lines 236-240):
+
+```python
+    async def comfyui_list_workflows() -> dict[str, Any]:
+        """List available workflow templates."""
+        limiter.check("list_workflows")
+        await audit.async_log(tool="list_workflows", action="called")
+        return await client.get_workflow_templates()
+```
+
+with:
+
+```python
+    async def comfyui_list_workflows(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+        """List workflow templates registered on the ComfyUI server (the ``/workflow_templates``
+        endpoint, populated by installed front-end packages).
+
+        This is distinct from ``comfyui_create_workflow``'s built-in template names
+        (txt2img, img2img, etc.) which are hard-coded in the MCP for graph generation.
+
+        Returns a paginated envelope: ``{items, total, offset, limit, has_more}``.
+        Each item is ``{"package": str, "templates": [...]}`` from the server.
+        """
+        limiter.check("list_workflows")
+        await audit.async_log(tool="list_workflows", action="called")
+        templates_by_package = await client.get_workflow_templates()
+        # client.get_workflow_templates returns dict[package_name, list[template]];
+        # flatten to a list of {package, templates} so paginate() can slice it.
+        items = [
+            {"package": package, "templates": templates}
+            for package, templates in (templates_by_package or {}).items()
+        ]
+        return paginate(items, offset, limit, default_limit=25, max_limit=100)
+```
+
+### Step 4: Update `tests/test_tools_discovery.py`
+
+- [ ] Replace `class TestListExtensions` (lines 95-106) with:
+
+```python
+class TestListExtensions:
+    @respx.mock
+    async def test_list_extensions(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/extensions").mock(
+            return_value=httpx.Response(200, json=["ext1", "ext2"])
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_list_extensions"]()
+        assert result["items"] == ["ext1", "ext2"]
+        assert result["total"] == 2
+        assert result["offset"] == 0
+        assert result["has_more"] is False
+```
+
+- [ ] Replace `class TestListModelFolders` (lines 123-135) with:
+
+```python
+class TestListModelFolders:
+    @respx.mock
+    async def test_list_model_folders(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/models").mock(
+            return_value=httpx.Response(200, json=["checkpoints", "loras", "vae"])
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_list_model_folders"]()
+        assert "checkpoints" in result["items"]
+        assert "loras" in result["items"]
+        assert result["total"] == 3
+        assert result["has_more"] is False
+```
+
+### Step 5: Verify or add a `TestListWorkflows` test
+
+- [ ] Search for existing tests for `comfyui_list_workflows` in `tests/test_tools_discovery.py`:
+
+Run: `grep -n "list_workflows\|TestListWorkflows" tests/test_tools_discovery.py`
+
+If a test exists, update its assertions to match the new envelope (`result["items"]`, `result["total"]`). If none exists, add this minimal test inside `tests/test_tools_discovery.py`:
+
+```python
+class TestListWorkflows:
+    @respx.mock
+    async def test_list_workflows_paginates(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/workflow_templates").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ComfyUI-Manager": ["templ_a", "templ_b"],
+                    "ComfyUI-Frontend": ["templ_c"],
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_list_workflows"]()
+        assert "items" in result
+        assert result["total"] == 2  # two packages, not three templates
+        assert result["has_more"] is False
+        package_names = {entry["package"] for entry in result["items"]}
+        assert package_names == {"ComfyUI-Manager", "ComfyUI-Frontend"}
+```
+
+### Step 6: Run all discovery tests
+
+- [ ] Run: `uv run pytest tests/test_tools_discovery.py -v`
+Expected: all PASS.
+
+### Step 7: Commit
+
+- [ ] ```bash
+git add src/comfyui_mcp/tools/discovery.py tests/test_tools_discovery.py
+git commit -m "Paginate comfyui_list_extensions, _model_folders, _workflows"
+```
+
+---
+
+## Task 6: Rename `id` → `node_id` in custom-node tools (BREAKING)
+
+The three node-management tools (`install_custom_node`, `uninstall_custom_node`, `update_custom_node`) currently use `id: str` as the parameter name with `# noqa: A002`. Rename to `node_id`, drop the noqa, add `Field` constraints. **This is a breaking change for MCP callers.**
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/nodes.py:273-326, 335-378, 388-440`
+- Test: `tests/test_tools_nodes.py`
+
+### Step 1: Update tool signatures and bodies in `nodes.py`
+
+- [ ] First, ensure `Annotated` and `Field` are imported in `nodes.py`. Check the imports at the top of the file. If they aren't already present, add to the existing typing import:
+
+```python
+from typing import Annotated, Any
+```
+
+and to a third-party import block:
+
+```python
+from pydantic import Field
+```
+
+Then replace the `comfyui_install_custom_node` signature (around line 273-277):
+
+```python
+    async def comfyui_install_custom_node(
+        id: str,  # noqa: A002
+        version: str = "",
+        restart: bool = False,
+    ) -> str:
+```
+
+with:
+
+```python
+    async def comfyui_install_custom_node(
+        node_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Custom-node pack ID from the ComfyUI Manager registry. "
+                "Use comfyui_search_custom_nodes to discover IDs.",
+            ),
+        ],
+        version: Annotated[
+            str,
+            Field(default="", description="Specific version to install. Empty string = latest."),
+        ] = "",
+        restart: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, restart ComfyUI after install and run a security audit.",
+            ),
+        ] = False,
+    ) -> str:
+```
+
+Then in the body (lines 281-323), replace **every** occurrence of `id` with `node_id`. Concretely:
+
+- `Args:` block: replace `id:` with `node_id:`.
+- `_validate_node_id(id)` → `_validate_node_id(node_id)`
+- `extra={"id": id, ...}` → `extra={"node_id": node_id, ...}` (both occurrences)
+- `params={...}` block: `"id": id,` → `"id": node_id,` (the wire-level key stays `id` because that's the upstream ComfyUI Manager API; only the Python parameter name changes)
+- `node_id=id,` → `node_id=node_id,` (this kwarg to `_execute_node_operation` already used `node_id` as the keyword)
+
+The same renames apply to `comfyui_uninstall_custom_node` (lines 335-378) and `comfyui_update_custom_node` (lines 388-440).
+
+For `comfyui_uninstall_custom_node`, the `params={...}` block uses `"node_name": id` — change to `"node_name": node_id`.
+
+For `comfyui_update_custom_node`, the `params={...}` block uses `"node_name": id` — change to `"node_name": node_id`.
+
+After all three tools are updated, signature for `uninstall`:
+
+```python
+    async def comfyui_uninstall_custom_node(
+        node_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Custom-node pack ID to uninstall.",
+            ),
+        ],
+        restart: Annotated[
+            bool,
+            Field(default=False, description="If True, restart ComfyUI after uninstall."),
+        ] = False,
+    ) -> str:
+```
+
+And `update`:
+
+```python
+    async def comfyui_update_custom_node(
+        node_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Custom-node pack ID to update to the latest version.",
+            ),
+        ],
+        restart: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, restart ComfyUI after update and run a security audit.",
+            ),
+        ] = False,
+    ) -> str:
+```
+
+Update the docstring `Args:` blocks for all three tools to reflect the rename.
+
+### Step 2: Update `comfyui_search_custom_nodes` to use shared fields
+
+- [ ] In `src/comfyui_mcp/tools/nodes.py`, find the existing `from comfyui_mcp.pagination import paginate` line and replace with:
+
+```python
+from comfyui_mcp.pagination import OffsetField, paginate
+```
+
+(Note: we use `OffsetField` here but keep the inline `LimitField` in this tool because its max is 25, not 100.)
+
+Then replace the `comfyui_search_custom_nodes` signature (lines 184-188):
+
+```python
+    async def comfyui_search_custom_nodes(
+        query: str,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+```
+
+with:
+
+```python
+    async def comfyui_search_custom_nodes(
+        query: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Search term matched against installed node-pack name, "
+                "ID, description, and author.",
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                default=10,
+                ge=1,
+                le=25,
+                description="Maximum number of matches to return (1-25).",
+            ),
+        ] = 10,
+        offset: OffsetField = 0,
+    ) -> dict[str, Any]:
+```
+
+### Step 3: Update tests for the rename
+
+- [ ] In `tests/test_tools_nodes.py`, find every test invocation that passes `id=` to the install/uninstall/update tools and rename to `node_id=`.
+
+Run: `grep -n 'tools\["comfyui_\(install\|uninstall\|update\)_custom_node"\](' tests/test_tools_nodes.py` to find call sites.
+
+For each call site, change:
+
+```python
+await tools["comfyui_install_custom_node"](id="some-pack")
+```
+
+to:
+
+```python
+await tools["comfyui_install_custom_node"](node_id="some-pack")
+```
+
+Same for `uninstall` and `update`.
+
+If any test passes `id` positionally without a keyword, leave it unchanged (positional still works, just the named argument changes).
+
+### Step 4: Run node tests
+
+- [ ] Run: `uv run pytest tests/test_tools_nodes.py -v`
+Expected: all PASS. If any test still passes `id=`, rename it.
+
+### Step 5: Run full test suite to catch any other callers
+
+- [ ] Run: `uv run pytest -v 2>&1 | tail -20`
+Expected: 0 failures.
+
+If anything fails because a test passed `id=` as a kwarg, rename it.
+
+### Step 6: Lint and format
+
+- [ ] Run: `uv run ruff check src/comfyui_mcp/tools/nodes.py && uv run ruff format src/comfyui_mcp/tools/nodes.py && uv run mypy src/comfyui_mcp/tools/nodes.py`
+Expected: clean. The `# noqa: A002` markers should now be gone with the parameter rename.
+
+### Step 7: Commit
+
+- [ ] ```bash
+git add src/comfyui_mcp/tools/nodes.py tests/test_tools_nodes.py
+git commit -m "Rename id->node_id in custom-node tools (BREAKING)
+
+Adds Field constraints (min_length=1, max_length=200) and removes the
+noqa A002 builtin-shadowing markers. MCP callers passing 'id' as a kwarg
+must update to 'node_id'."
+```
+
+---
+
+## Task 7: Rename `format` → `output_format` in `comfyui_summarize_workflow` (BREAKING)
+
+The tool's `format: str` parameter shadows the `format` builtin (silenced with `# noqa: A002`) and is hand-validated against `{"text", "mermaid"}`. Rename to `output_format` and use `Literal["text", "mermaid"]` so the schema advertises the choices.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/generation.py:553-597`
+- Test: `tests/test_tools_generation.py`
+
+### Step 1: Update the tool signature and body
+
+- [ ] In `src/comfyui_mcp/tools/generation.py`, ensure `Literal` is imported (the file already imports `Annotated`, `Any`; check whether `Literal` is in the `from typing import` line — if not, add it).
+
+Then replace lines 553-597 (whole function), starting from:
+
+```python
+    async def comfyui_summarize_workflow(workflow: str, format: str = "text") -> str:  # noqa: A002
+        """Summarize a ComfyUI workflow's structure, data flow, and key parameters.
+```
+
+with:
+
+```python
+    async def comfyui_summarize_workflow(
+        workflow: Annotated[
+            str,
+            Field(
+                description="JSON string of a ComfyUI workflow (API format). "
+                "Each top-level key is a node ID, each value has 'class_type' and 'inputs'.",
+            ),
+        ],
+        output_format: Annotated[
+            Literal["text", "mermaid"],
+            Field(
+                default="text",
+                description="Output format: 'text' (human-readable summary) or "
+                "'mermaid' (Mermaid flowchart markup).",
+            ),
+        ] = "text",
+    ) -> str:
+        """Summarize a ComfyUI workflow's structure, data flow, and key parameters.
+
+        Parses the workflow graph, extracts models, parameters, and execution flow.
+        Enriches with display names from the ComfyUI server when available.
+        """
+        summary_limiter = read_limiter if read_limiter is not None else limiter
+        summary_limiter.check("summarize_workflow")
+
+        try:
+            wf = json.loads(workflow)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON workflow: {e}") from e
+
+        if not isinstance(wf, dict):
+            raise ValueError("Workflow must be a JSON object keyed by node IDs")
+
+        # Best-effort API enrichment
+        object_info: dict[str, Any] | None = None
+        with contextlib.suppress(httpx.HTTPError, OSError):
+            object_info = await client.get_object_info()
+
+        analysis = _analyze_workflow(wf, object_info)
+        await audit.async_log(
+            tool="summarize_workflow",
+            action="summarized",
+            extra={
+                "node_count": analysis["node_count"],
+                "pipeline": analysis["pipeline"],
+                "format": output_format,
+            },
+        )
+        if output_format == "mermaid":
+            return _format_mermaid(analysis)
+        return _format_summary(analysis)
+```
+
+The hand-written `output_format = format.lower().strip()` and `if output_format not in {"text", "mermaid"}` checks are removed because pydantic's `Literal` enforces them at the schema/validation boundary.
+
+### Step 2: Update tests for the rename
+
+- [ ] In `tests/test_tools_generation.py`, find every call to `comfyui_summarize_workflow` and rename `format=` to `output_format=`.
+
+Run: `grep -n 'comfyui_summarize_workflow' tests/test_tools_generation.py`
+
+For each call site that passes `format="..."` rename to `output_format="..."`. Calls that pass only `workflow=...` are unaffected.
+
+### Step 3: Run tests
+
+- [ ] Run: `uv run pytest tests/test_tools_generation.py -v -k summarize`
+Expected: all PASS.
+
+### Step 4: Lint and format
+
+- [ ] Run: `uv run ruff check src/comfyui_mcp/tools/generation.py && uv run ruff format src/comfyui_mcp/tools/generation.py && uv run mypy src/comfyui_mcp/tools/generation.py`
+Expected: clean. The `# noqa: A002` should be gone.
+
+### Step 5: Commit
+
+- [ ] ```bash
+git add src/comfyui_mcp/tools/generation.py tests/test_tools_generation.py
+git commit -m "Rename summarize_workflow format->output_format with Literal type (BREAKING)
+
+Replaces hand-rolled validation with pydantic Literal['text', 'mermaid'].
+MCP callers passing 'format' as a kwarg must update to 'output_format'."
+```
+
+---
+
+## Task 8: Beef up stub docstrings
+
+Improve four stub-quality docstrings (`list_extensions`, `list_model_folders`, `get_server_features`, `get_node_info`) and add cross-references between `comfyui_run_workflow` and `comfyui_run_workflow_stream`.
+
+Note: `comfyui_list_extensions` and `comfyui_list_model_folders` already had docstring upgrades in Task 5 (the new docstrings include detail and pagination shape). This task covers the remaining three plus the run_workflow cross-references.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/discovery.py` (`get_server_features`, `get_node_info`)
+- Modify: `src/comfyui_mcp/tools/generation.py` (`run_workflow`, `run_workflow_stream` docstrings)
+
+### Step 1: Update `comfyui_get_server_features` docstring
+
+- [ ] In `src/comfyui_mcp/tools/discovery.py`, replace lines 268-272:
+
+```python
+    async def comfyui_get_server_features() -> dict[str, Any]:
+        """Get ComfyUI server features and capabilities."""
+        limiter.check("get_server_features")
+        await audit.async_log(tool="get_server_features", action="called")
+        return await client.get_features()
+```
+
+with:
+
+```python
+    async def comfyui_get_server_features() -> dict[str, Any]:
+        """Get the feature flags advertised by the ComfyUI server.
+
+        Returns the raw ``/features`` response — typically a dict of
+        {feature_name: bool}. Useful for capability-based branching, e.g.
+        checking ``supports_preview_metadata`` before requesting preview-format
+        images via ``comfyui_get_image``.
+        """
+        limiter.check("get_server_features")
+        await audit.async_log(tool="get_server_features", action="called")
+        return await client.get_features()
+```
+
+### Step 2: Update `comfyui_get_node_info` to add Field description
+
+- [ ] In `src/comfyui_mcp/tools/discovery.py`, find the `comfyui_get_node_info` definition. The current signature (line 218) is:
+
+```python
+    async def comfyui_get_node_info(node_class: str) -> dict[str, Any]:
+        """Get detailed information about a specific node type."""
+```
+
+Replace with:
+
+```python
+    async def comfyui_get_node_info(
+        node_class: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Node class name (e.g. 'KSampler', 'CLIPTextEncode'). "
+                "Use comfyui_list_nodes to discover available class names.",
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Get the input/output schema and metadata for a single ComfyUI node type.
+
+        Returns a dict with keys: input, input_order, is_input_list, output,
+        output_is_list, output_name, name, display_name, description, python_module,
+        category, output_node, search_aliases, plus optional flags like deprecated,
+        experimental, and api_node when set on the node.
+        """
+```
+
+Ensure `Annotated` and `Field` are already imported in `discovery.py`. If not, add them — check the existing imports.
+
+### Step 3: Cross-reference run_workflow and run_workflow_stream
+
+- [ ] In `src/comfyui_mcp/tools/generation.py`, find `comfyui_run_workflow` and `comfyui_run_workflow_stream`. Add a "See also:" line to each docstring pointing at the other.
+
+For `comfyui_run_workflow`, locate its docstring (search for `async def comfyui_run_workflow(`) and append at the end of the existing docstring (before the closing `"""`):
+
+```
+        See also: comfyui_run_workflow_stream for a streaming variant that emits
+        per-node progress events while the workflow executes.
+```
+
+For `comfyui_run_workflow_stream`, append:
+
+```
+        See also: comfyui_run_workflow for a non-streaming variant. Use this
+        streaming version when you need real-time per-node progress events
+        (intended for tooling that surfaces progress to a user); use the
+        non-streaming variant for fire-and-forget submission or when you only
+        need the final result.
+```
+
+### Step 4: Run tests
+
+- [ ] Run: `uv run pytest tests/test_tools_discovery.py tests/test_tools_generation.py -v`
+Expected: all PASS — pure docstring/annotation changes, no runtime behavior change.
+
+### Step 5: Lint and format
+
+- [ ] Run: `uv run ruff check src/ && uv run ruff format --check src/ && uv run mypy src/comfyui_mcp/`
+Expected: clean.
+
+### Step 6: Commit
+
+- [ ] ```bash
+git add src/comfyui_mcp/tools/discovery.py src/comfyui_mcp/tools/generation.py
+git commit -m "Improve stub docstrings and cross-reference run_workflow variants"
+```
+
+---
+
+## Task 9: README update
+
+Document the breaking parameter renames so callers know to update.
+
+**Files:**
+- Modify: `README.md`
+
+### Step 1: Find the right section
+
+- [ ] Run: `grep -n "comfyui_install_custom_node\|comfyui_summarize_workflow\|## Breaking Changes\|## Migration" README.md`
+
+Note where the custom-node and summarize tools are mentioned.
+
+### Step 2: Add a Breaking Changes section near the top of the README
+
+- [ ] Find the line after the README's main description (typically near the top, after the title/badges/intro paragraph but before the install section). Search for a line like `## Installation` or `## Quick Start`.
+
+Insert this block immediately before that section:
+
+```markdown
+## Recent Breaking Changes (2026-05)
+
+**Parameter renames** — update keyword arguments (positional calls are unaffected):
+- `comfyui_install_custom_node`, `comfyui_uninstall_custom_node`,
+  `comfyui_update_custom_node`: `id` → `node_id`.
+- `comfyui_summarize_workflow`: `format` → `output_format`, restricted to
+  `text` or `mermaid` via a Pydantic `Literal`.
+
+**Response-shape changes** — these tools now return the standard pagination envelope
+`{items, total, offset, limit, has_more}` instead of bare lists or raw dicts:
+- `comfyui_list_extensions` (was: `list[str]`)
+- `comfyui_list_model_folders` (was: `list[str]`)
+- `comfyui_list_workflows` (was: `dict[package_name, list[template]]`; now flattened
+  to `items: [{package, templates}]`)
+
+Callers must update to read `result["items"]` instead of indexing the response
+directly. The new envelope also exposes `limit` and `offset` parameters for
+pagination.
+```
+
+### Step 3: Commit
+
+- [ ] ```bash
+git add README.md
+git commit -m "Document Task 6 and Task 7 parameter renames in README"
+```
+
+---
+
+## Task 10: Final verification sweep
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest -v 2>&1 | tail -20`
+Expected: ALL PASS, no skipped, no errors.
+
+- [ ] **Step 2: Run the linter**
+
+Run: `uv run ruff check src/ tests/`
+Expected: no diagnostics.
+
+- [ ] **Step 3: Run the formatter check**
+
+Run: `uv run ruff format --check src/ tests/`
+Expected: no diff.
+
+- [ ] **Step 4: Run the type checker**
+
+Run: `uv run mypy src/comfyui_mcp/`
+Expected: 0 errors.
+
+- [ ] **Step 5: Run pre-commit (only on tracked files we touched)**
+
+Run: `uv run pre-commit run --files $(git diff --name-only main...HEAD | grep -v graphify-out)`
+Expected: all hooks pass.
+
+If unrelated files in the working tree get reformatted (preexisting drift like `tests/test_blocked_endpoints.py`), restore them with `git checkout -- <file>` and document the drift outside this PR.
+
+- [ ] **Step 6: Verify tool surface unchanged in count**
+
+Run: `grep -rn "@mcp.tool" src/comfyui_mcp/tools/ | wc -l`
+Expected: same number as before this work began (this PR adds zero new tools — only modifies existing ones).
+
+- [ ] **Step 7: Confirm no `# noqa: A002` markers remain in the touched tools**
+
+Run: `grep -n "noqa: A002" src/comfyui_mcp/tools/`
+Expected: no matches in `nodes.py` or `generation.py`. If any other file still has `# noqa: A002`, that's outside this plan's scope and can stay.
+
+If any verification step fails, fix and amend the appropriate commit (or add a fixup commit) before declaring the plan complete.
+
+---
+
+## Out of scope (deliberately not in this plan)
+
+- Audit Important #6 generic upload-tool Field annotation drift (`comfyui_upload_image`, `comfyui_upload_mask`). Touching these would interact with the security/sanitizer layer which was excluded from the audit; defer.
+- Minor #10 unified return envelope for `wait=True` generation tools — larger refactor.
+- Minor #14 `comfyui_search_models` redundant validation — cosmetic.
+- Project observation A cursor-based pagination — none of the tools' datasets warrant it yet.

--- a/docs/superpowers/plans/2026-05-10-upstream-api-updates.md
+++ b/docs/superpowers/plans/2026-05-10-upstream-api-updates.md
@@ -1,0 +1,909 @@
+# Upstream API Updates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt three deferred ComfyUI upstream-API capabilities in a single PR. (1) `/view?preview=webp;90` server-side thumbnails — significant bandwidth/context-window win when LLMs fetch images. (2) `/upload/image` `type` and `overwrite` params — gives callers explicit control over destination and replacement. (3) `/history?offset=N` server-side offset paging — adds a client-API capability for paging beyond the 1000-entry window.
+
+**Architecture:** All three are passthrough extensions: client method signatures gain optional parameters, tools expose them via `Annotated[..., Field(...)]`, security primitives (sanitizer, rate limiter, audit logger) stay intact and apply at the same enforcement points. For (2) `upload_image` `type`, restrict the accepted values to a `Literal["input", "output", "temp"]` so callers cannot pass arbitrary destinations. For (3) the tool layer stays unchanged in this PR — the client API addition is the deliverable; refactoring `comfyui_get_history` to use server-side offset is deferred.
+
+**Tech Stack:** Python 3.12, httpx (async), respx (HTTP mocking), pytest with `asyncio_mode = auto`, FastMCP, Pydantic `Field`/`Literal`/`Annotated`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/comfyui_mcp/client.py` — extend `get_image`, `upload_image`, `get_history` method signatures.
+- `src/comfyui_mcp/tools/files.py` — extend `comfyui_get_image` (preview) and `comfyui_upload_image` (type/overwrite) tools.
+- `tests/test_client.py` — tests for the three new client capabilities.
+- `tests/test_tools_files.py` — tests for the two new tool parameter sets.
+- `README.md` — note the new tool params in the Tools section.
+
+No new files.
+
+---
+
+## Task 1: Add `preview` support to `client.get_image`
+
+ComfyUI `/view` accepts `preview=webp;<quality>` or `preview=jpeg;<quality>` to return a server-rendered thumbnail in the requested format. The response's `Content-Type` reflects the chosen format. Use case: large generated PNGs become small webp thumbnails for LLM context.
+
+**Files:**
+- Modify: `src/comfyui_mcp/client.py:248-260` (the `get_image` method)
+- Test: `tests/test_client.py` (add to `TestComfyUIClient`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_client.py` inside `class TestComfyUIClient:`:
+
+```python
+    @respx.mock
+    async def test_get_image_preview_webp(self, client):
+        route = respx.get("http://test-comfyui:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"fake-webp-bytes",
+                headers={"content-type": "image/webp"},
+            )
+        )
+        data, content_type = await client.get_image("out.png", preview="webp;90")
+        assert data == b"fake-webp-bytes"
+        assert content_type == "image/webp"
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["filename"] == "out.png"
+        assert params["preview"] == "webp;90"
+        assert params["type"] == "output"
+
+    @respx.mock
+    async def test_get_image_preview_jpeg(self, client):
+        route = respx.get("http://test-comfyui:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"fake-jpeg-bytes",
+                headers={"content-type": "image/jpeg"},
+            )
+        )
+        await client.get_image("out.png", preview="jpeg;75")
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["preview"] == "jpeg;75"
+
+    @respx.mock
+    async def test_get_image_without_preview_omits_param(self, client):
+        route = respx.get("http://test-comfyui:8188/view").mock(
+            return_value=httpx.Response(200, content=b"png-bytes", headers={"content-type": "image/png"})
+        )
+        await client.get_image("out.png")
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert "preview" not in params
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_client.py -v -k "test_get_image_preview or test_get_image_without_preview"`
+Expected: 2 of 3 fail (the no-preview test passes since current behavior already omits `preview`); the two preview tests fail because `get_image` doesn't accept the kwarg yet.
+
+- [ ] **Step 3: Update `client.get_image`**
+
+In `src/comfyui_mcp/client.py`, replace the existing `get_image` method:
+
+```python
+    async def get_image(
+        self,
+        filename: str,
+        subfolder: str = "",
+        *,
+        preview: str | None = None,
+    ) -> tuple[bytes, str]:
+        """GET /view — download an output image by filename and subfolder.
+
+        Args:
+            filename: Image filename in ComfyUI's output dir.
+            subfolder: Subfolder within ComfyUI's output dir.
+            preview: Optional thumbnail spec passed to ComfyUI as ``preview=<spec>``.
+                Format ``<format>;<quality>`` where format is ``webp`` or ``jpeg``
+                and quality is 1-100. ComfyUI re-encodes the image server-side.
+        """
+        params: dict[str, str] = {
+            "filename": filename,
+            "subfolder": subfolder,
+            "type": "output",
+        }
+        if preview is not None:
+            params["preview"] = preview
+        r = await self._request("get", "/view", params=params)
+        content_type = r.headers.get("content-type", "image/png")
+        return r.content, content_type
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_client.py -v -k "test_get_image"`
+Expected: all PASS (including pre-existing get_image tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/comfyui_mcp/client.py tests/test_client.py
+git commit -m "Add preview kwarg to client.get_image for server-rendered thumbnails"
+```
+
+---
+
+## Task 2: Expose preview thumbnail support in `comfyui_get_image` tool
+
+The tool gains two new optional parameters: `preview_format` (Literal `"webp"` / `"jpeg"`) and `preview_quality` (int 1-100). When both are provided, they're combined into the `preview=<fmt>;<q>` spec passed to the client.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/files.py` (the `comfyui_get_image` function)
+- Test: `tests/test_tools_files.py`
+
+- [ ] **Step 1: Read the test file to learn the components fixture and existing tests**
+
+Run: `grep -n "TestGetImage\|def components\|class Test" tests/test_tools_files.py | head -15`
+
+Note the fixture name and the existing TestGetImage class location so the new tests slot in cleanly.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `tests/test_tools_files.py` inside the existing test class for get_image (or as a new sibling class `TestGetImagePreview`):
+
+```python
+class TestGetImagePreview:
+    @respx.mock
+    async def test_data_uri_with_webp_preview(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"webp-bytes",
+                headers={"content-type": "image/webp"},
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_get_image"](
+            filename="out.png",
+            preview_format="webp",
+            preview_quality=85,
+        )
+        assert result.startswith("data:image/webp;base64,")
+
+    @respx.mock
+    async def test_data_uri_with_jpeg_preview(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.get("http://test:8188/view").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"jpeg-bytes",
+                headers={"content-type": "image/jpeg"},
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        await tools["comfyui_get_image"](
+            filename="out.png",
+            preview_format="jpeg",
+            preview_quality=50,
+        )
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["preview"] == "jpeg;50"
+
+    async def test_quality_without_format_rejected(self, components):
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        with pytest.raises(ValueError, match="preview_format"):
+            await tools["comfyui_get_image"](
+                filename="out.png",
+                preview_quality=85,
+            )
+
+    async def test_url_format_ignores_preview(self, components):
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_file_tools(
+            mcp, client, audit, limiter, sanitizer,
+        )
+        # When response_format='url', preview params should be ignored
+        # (the returned /view URL is unchanged; LLMs that want a thumbnail
+        # should use response_format='data_uri').
+        result = await tools["comfyui_get_image"](
+            filename="out.png",
+            response_format="url",
+            preview_format="webp",
+            preview_quality=80,
+        )
+        assert "/view?" in result
+        assert "preview" not in result
+```
+
+Make sure `pytest` is imported at the top of the test file (it should already be).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_tools_files.py::TestGetImagePreview -v`
+Expected: all 4 FAIL — the tool doesn't accept the new params.
+
+- [ ] **Step 4: Update the tool**
+
+In `src/comfyui_mcp/tools/files.py`, replace the existing `comfyui_get_image` signature and body. The current header was:
+
+```python
+    async def comfyui_get_image(
+        filename: Annotated[str, Field(description="Name of the image file to retrieve")],
+        subfolder: Annotated[
+            str,
+            Field(
+                description="Subfolder within ComfyUI's output directory. "
+                "Use the subfolder value from comfyui_list_outputs or generation results."
+            ),
+        ] = "",
+        response_format: Annotated[
+            Literal["data_uri", "url"],
+            Field(description="'data_uri' to inline the image, or 'url' to return a /view URL"),
+        ] = "data_uri",
+        base_url_override: Annotated[
+            str | None,
+            Field(
+                description="Optional override for URL responses; falls back to configured base URL"
+            ),
+        ] = None,
+    ) -> str:
+        """Download a generated image from ComfyUI or return a direct view URL.
+
+        Returns:
+            Base64-encoded image data with content type prefix, or a direct image URL
+        """
+        limiter.check("get_image")
+        clean_name = sanitizer.validate_filename(filename)
+        clean_subfolder = sanitizer.validate_subfolder(subfolder)
+        await audit.async_log(
+            tool="get_image",
+            action="downloading",
+            extra={"filename": clean_name, "response_format": response_format},
+        )
+
+        resolved_base_url = base_url_override or image_view_base_url
+
+        if response_format == "url":
+            return client.build_image_url(
+                clean_name,
+                clean_subfolder,
+                base_url=resolved_base_url,
+            )
+
+        if response_format != "data_uri":
+            raise ValueError("response_format must be 'data_uri' or 'url'")
+
+        data, content_type = await client.get_image(
+            clean_name,
+            clean_subfolder,
+        )
+        b64 = base64.b64encode(data).decode()
+        return f"data:{content_type};base64,{b64}"
+```
+
+Replace it with:
+
+```python
+    async def comfyui_get_image(
+        filename: Annotated[str, Field(description="Name of the image file to retrieve")],
+        subfolder: Annotated[
+            str,
+            Field(
+                description="Subfolder within ComfyUI's output directory. "
+                "Use the subfolder value from comfyui_list_outputs or generation results."
+            ),
+        ] = "",
+        response_format: Annotated[
+            Literal["data_uri", "url"],
+            Field(description="'data_uri' to inline the image, or 'url' to return a /view URL"),
+        ] = "data_uri",
+        base_url_override: Annotated[
+            str | None,
+            Field(
+                description="Optional override for URL responses; falls back to configured base URL"
+            ),
+        ] = None,
+        preview_format: Annotated[
+            Literal["webp", "jpeg"] | None,
+            Field(
+                default=None,
+                description="If set with response_format='data_uri', request a server-rendered "
+                "thumbnail in this format instead of the original (smaller payload, lossy).",
+            ),
+        ] = None,
+        preview_quality: Annotated[
+            int | None,
+            Field(
+                default=None,
+                ge=1,
+                le=100,
+                description="Encoder quality (1-100) for preview_format. Default: 90 when "
+                "preview_format is set.",
+            ),
+        ] = None,
+    ) -> str:
+        """Download a generated image from ComfyUI or return a direct view URL.
+
+        Returns:
+            Base64-encoded image data with content type prefix, or a direct image URL.
+            When response_format='data_uri' and preview_format is set, ComfyUI re-encodes
+            the image server-side as a smaller webp or jpeg thumbnail.
+        """
+        if preview_quality is not None and preview_format is None:
+            raise ValueError(
+                "preview_quality is only meaningful when preview_format is also set"
+            )
+
+        limiter.check("get_image")
+        clean_name = sanitizer.validate_filename(filename)
+        clean_subfolder = sanitizer.validate_subfolder(subfolder)
+        await audit.async_log(
+            tool="get_image",
+            action="downloading",
+            extra={
+                "filename": clean_name,
+                "response_format": response_format,
+                "preview_format": preview_format,
+            },
+        )
+
+        resolved_base_url = base_url_override or image_view_base_url
+
+        if response_format == "url":
+            # Preview params don't apply to URL responses — the returned URL
+            # is a direct /view link; callers wanting a thumbnail should
+            # request response_format='data_uri'.
+            return client.build_image_url(
+                clean_name,
+                clean_subfolder,
+                base_url=resolved_base_url,
+            )
+
+        if response_format != "data_uri":
+            raise ValueError("response_format must be 'data_uri' or 'url'")
+
+        preview_spec: str | None = None
+        if preview_format is not None:
+            quality = preview_quality if preview_quality is not None else 90
+            preview_spec = f"{preview_format};{quality}"
+
+        data, content_type = await client.get_image(
+            clean_name,
+            clean_subfolder,
+            preview=preview_spec,
+        )
+        b64 = base64.b64encode(data).decode()
+        return f"data:{content_type};base64,{b64}"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_tools_files.py -v -k "GetImage"`
+Expected: all pass (existing TestGetImage tests + the 4 new TestGetImagePreview tests).
+
+- [ ] **Step 6: Lint and type-check**
+
+Run: `uv run ruff check src/comfyui_mcp/tools/files.py && uv run ruff format src/comfyui_mcp/tools/files.py && uv run mypy src/comfyui_mcp/tools/files.py`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/files.py tests/test_tools_files.py
+git commit -m "Expose preview thumbnail params on comfyui_get_image"
+```
+
+---
+
+## Task 3: Add `type` and `overwrite` support to `client.upload_image`
+
+ComfyUI `/upload/image` accepts `type` (input/output/temp) and `overwrite` ("true"/"1") as form fields. Default behavior preserved: type=input, no overwrite (server auto-renames `name (1).png`).
+
+**Files:**
+- Modify: `src/comfyui_mcp/client.py:240-246`
+- Test: `tests/test_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_client.py` inside `class TestComfyUIClient:`:
+
+```python
+    @respx.mock
+    async def test_upload_image_default_type(self, client):
+        # Default behavior: form does not include 'type' or 'overwrite' fields
+        route = respx.post("http://test-comfyui:8188/upload/image").mock(
+            return_value=httpx.Response(200, json={"name": "x.png", "subfolder": "", "type": "input"})
+        )
+        await client.upload_image(b"data", "x.png")
+        body = route.calls.last.request.content
+        # multipart form encoded — check that type/overwrite are NOT present
+        assert b'name="type"' not in body
+        assert b'name="overwrite"' not in body
+
+    @respx.mock
+    async def test_upload_image_with_type_and_overwrite(self, client):
+        route = respx.post("http://test-comfyui:8188/upload/image").mock(
+            return_value=httpx.Response(200, json={"name": "x.png", "subfolder": "", "type": "output"})
+        )
+        await client.upload_image(
+            b"data",
+            "x.png",
+            destination="output",
+            overwrite=True,
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' in body
+        assert b"output" in body
+        assert b'name="overwrite"' in body
+        assert b"true" in body
+
+    async def test_upload_image_rejects_invalid_destination(self, client):
+        with pytest.raises(ValueError, match="destination"):
+            await client.upload_image(b"data", "x.png", destination="garbage")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_client.py -v -k "test_upload_image"`
+Expected: the two new tests with `destination` kwarg fail (TypeError: unexpected keyword argument). The default-type test passes against current code since the form is empty by default — but pre-existing `test_upload_image` should still pass.
+
+- [ ] **Step 3: Update `client.upload_image`**
+
+In `src/comfyui_mcp/client.py`, replace lines 240-246:
+
+```python
+    async def upload_image(self, data: bytes, filename: str, subfolder: str = "") -> dict:
+        files = {"image": (filename, data, "image/png")}
+        form_data: dict[str, str] = {}
+        if subfolder:
+            form_data["subfolder"] = subfolder
+        r = await self._request("post", "/upload/image", files=files, data=form_data)
+        return r.json()
+```
+
+with:
+
+```python
+    async def upload_image(
+        self,
+        data: bytes,
+        filename: str,
+        subfolder: str = "",
+        *,
+        destination: str = "input",
+        overwrite: bool = False,
+    ) -> dict:
+        """POST /upload/image — upload an image to ComfyUI.
+
+        Args:
+            data: Raw image bytes.
+            filename: Target filename in ComfyUI's storage.
+            subfolder: Optional subfolder within the destination.
+            destination: Destination type. One of "input" (default), "output", "temp".
+                The wire field name is ``type`` — renamed here to avoid shadowing the
+                Python builtin.
+            overwrite: If True, replace an existing file with the same name. If False
+                (default), ComfyUI auto-renames by suffixing ``(N)`` when a duplicate
+                exists.
+        """
+        if destination not in {"input", "output", "temp"}:
+            raise ValueError(
+                f"destination must be one of 'input', 'output', 'temp'; got {destination!r}"
+            )
+        files = {"image": (filename, data, "image/png")}
+        form_data: dict[str, str] = {}
+        if subfolder:
+            form_data["subfolder"] = subfolder
+        # Only include 'type'/'overwrite' when the caller deviates from defaults —
+        # keeps the request body identical to historical behavior in the common case.
+        if destination != "input":
+            form_data["type"] = destination
+        if overwrite:
+            form_data["overwrite"] = "true"
+        r = await self._request("post", "/upload/image", files=files, data=form_data)
+        return r.json()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_client.py -v -k "test_upload_image"`
+Expected: all PASS, including the pre-existing `test_upload_image`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/comfyui_mcp/client.py tests/test_client.py
+git commit -m "Add destination/overwrite kwargs to client.upload_image"
+```
+
+---
+
+## Task 4: Expose `destination` and `overwrite` on `comfyui_upload_image` tool
+
+**Security note:** this is a deliberate widening of the tool surface. The default stays `destination="input"` so existing callers see no behavior change. The tool restricts `destination` to a `Literal` so callers cannot pass arbitrary directory names; `overwrite` is a bool. The path sanitizer's filename validation still applies to all destinations. Upstream ComfyUI also enforces `os.path.commonpath` against traversal regardless of which destination we choose.
+
+**Files:**
+- Modify: `src/comfyui_mcp/tools/files.py` (the `comfyui_upload_image` function)
+- Test: `tests/test_tools_files.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_tools_files.py`:
+
+```python
+class TestUploadImageDestination:
+    @respx.mock
+    async def test_upload_to_output_dir(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "output"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_upload_image"](
+            filename="x.png",
+            image_data="ZGF0YQ==",  # base64 "data"
+            destination="output",
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' in body
+        assert b"output" in body
+        assert "Uploaded" in result
+
+    @respx.mock
+    async def test_upload_with_overwrite(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "input"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        await tools["comfyui_upload_image"](
+            filename="x.png",
+            image_data="ZGF0YQ==",
+            overwrite=True,
+        )
+        body = route.calls.last.request.content
+        assert b'name="overwrite"' in body
+        assert b"true" in body
+
+    @respx.mock
+    async def test_upload_default_unchanged(self, components):
+        # Verify existing default-call behavior is byte-identical to before:
+        # no 'type' or 'overwrite' fields in the multipart body.
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/image").mock(
+            return_value=httpx.Response(
+                200, json={"name": "x.png", "subfolder": "", "type": "input"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        await tools["comfyui_upload_image"](
+            filename="x.png",
+            image_data="ZGF0YQ==",
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' not in body
+        assert b'name="overwrite"' not in body
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_tools_files.py::TestUploadImageDestination -v`
+Expected: the two parametrized tests fail (tool doesn't accept `destination`/`overwrite` kwargs).
+
+- [ ] **Step 3: Update the tool**
+
+In `src/comfyui_mcp/tools/files.py`, replace the existing `comfyui_upload_image`:
+
+```python
+    async def comfyui_upload_image(filename: str, image_data: str, subfolder: str = "") -> str:
+        """Upload an image to ComfyUI's input directory.
+
+        Args:
+            filename: Name for the uploaded file (e.g. 'reference.png')
+            image_data: Base64-encoded image data
+            subfolder: Optional subfolder within ComfyUI's input directory
+        """
+        limiter.check("upload_image")
+        clean_name = sanitizer.validate_filename(filename)
+        clean_subfolder = sanitizer.validate_subfolder(subfolder)
+        raw = base64.b64decode(image_data)
+        sanitizer.validate_size(len(raw))
+        await audit.async_log(
+            tool="upload_image",
+            action="uploading",
+            extra={"filename": clean_name, "size_bytes": len(raw)},
+        )
+        result = await client.upload_image(raw, clean_name, clean_subfolder)
+        await audit.async_log(tool="upload_image", action="uploaded", extra={"result": result})
+        return f"Uploaded {result.get('name', clean_name)} to ComfyUI input directory"
+```
+
+with:
+
+```python
+    async def comfyui_upload_image(
+        filename: Annotated[
+            str,
+            Field(description="Name for the uploaded file (e.g. 'reference.png')"),
+        ],
+        image_data: Annotated[
+            str,
+            Field(description="Base64-encoded image data"),
+        ],
+        subfolder: Annotated[
+            str,
+            Field(default="", description="Optional subfolder within the destination directory"),
+        ] = "",
+        destination: Annotated[
+            Literal["input", "output", "temp"],
+            Field(
+                default="input",
+                description="Destination directory. 'input' (default) is where workflows "
+                "read user-supplied images from; 'output' and 'temp' are usually only "
+                "useful for testing or scripted setups.",
+            ),
+        ] = "input",
+        overwrite: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, replace any existing file with the same name. If False "
+                "(default), ComfyUI auto-renames by suffixing ' (N)'.",
+            ),
+        ] = False,
+    ) -> str:
+        """Upload an image to ComfyUI.
+
+        Defaults to ComfyUI's input directory (the destination workflows read from).
+        Set destination='output' or 'temp' only if you have a specific reason.
+        """
+        limiter.check("upload_image")
+        clean_name = sanitizer.validate_filename(filename)
+        clean_subfolder = sanitizer.validate_subfolder(subfolder)
+        raw = base64.b64decode(image_data)
+        sanitizer.validate_size(len(raw))
+        await audit.async_log(
+            tool="upload_image",
+            action="uploading",
+            extra={
+                "filename": clean_name,
+                "size_bytes": len(raw),
+                "destination": destination,
+                "overwrite": overwrite,
+            },
+        )
+        result = await client.upload_image(
+            raw,
+            clean_name,
+            clean_subfolder,
+            destination=destination,
+            overwrite=overwrite,
+        )
+        await audit.async_log(tool="upload_image", action="uploaded", extra={"result": result})
+        return f"Uploaded {result.get('name', clean_name)} to ComfyUI {destination} directory"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_tools_files.py -v -k "UploadImage"`
+Expected: all pass — existing UploadImage tests plus the new TestUploadImageDestination tests.
+
+- [ ] **Step 5: Run the security invariants to confirm the tool still has sanitizer in its closure**
+
+Run: `uv run pytest tests/test_security_invariants.py -v`
+Expected: all PASS. `comfyui_upload_image` is in the `FILE_HANDLING_TOOLS` allowlist and uses `sanitizer.validate_filename` / `validate_subfolder` — these checks still happen up front.
+
+- [ ] **Step 6: Lint and type-check**
+
+Run: `uv run ruff check src/comfyui_mcp/tools/files.py && uv run ruff format src/comfyui_mcp/tools/files.py && uv run mypy src/comfyui_mcp/tools/files.py`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/comfyui_mcp/tools/files.py tests/test_tools_files.py
+git commit -m "Expose destination/overwrite on comfyui_upload_image
+
+Restricts destination to Literal['input', 'output', 'temp'] so callers
+can't pass arbitrary directory names. Sanitizer validation still applies
+to filename and subfolder. Default stays 'input' — existing callers see
+no behavior change."
+```
+
+---
+
+## Task 5: Add `offset` support to `client.get_history`
+
+Upstream `/history` accepts `offset` (default -1, meaning no offset). This task adds the client capability. The `comfyui_get_history` tool is unchanged in this PR — the tool layer's full conversion to server-side offset is deferred (the response-shape `total` becomes ambiguous; needs separate design).
+
+**Files:**
+- Modify: `src/comfyui_mcp/client.py:158-165` (the `get_history` method)
+- Test: `tests/test_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_client.py` inside `class TestComfyUIClient:`:
+
+```python
+    @respx.mock
+    async def test_get_history_with_offset(self, client):
+        route = respx.get("http://test-comfyui:8188/history").mock(
+            return_value=httpx.Response(200, json={"abc": {"outputs": {}}})
+        )
+        await client.get_history(max_items=100, offset=50)
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["offset"] == "50"
+        assert params["max_items"] == "100"
+
+    @respx.mock
+    async def test_get_history_without_offset_omits_param(self, client):
+        route = respx.get("http://test-comfyui:8188/history").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        await client.get_history(max_items=100)
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert "offset" not in params
+
+    async def test_get_history_rejects_negative_offset(self, client):
+        with pytest.raises(ValueError, match="offset"):
+            await client.get_history(max_items=100, offset=-1)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_client.py -v -k "test_get_history"`
+Expected: the new tests fail (the method doesn't accept `offset`).
+
+- [ ] **Step 3: Update the method**
+
+In `src/comfyui_mcp/client.py`, replace lines 158-165:
+
+```python
+    async def get_history(self, max_items: int | None = None) -> dict:
+        params: dict[str, int] = {}
+        if max_items is not None:
+            if max_items <= 0:
+                raise ValueError("max_items must be a positive integer")
+            params["max_items"] = min(max_items, 1000)
+        r = await self._request("get", "/history", params=params or None)
+        return r.json()
+```
+
+with:
+
+```python
+    async def get_history(
+        self,
+        max_items: int | None = None,
+        *,
+        offset: int | None = None,
+    ) -> dict:
+        """GET /history — fetch execution history with optional pagination.
+
+        Args:
+            max_items: Maximum number of history entries to return. Capped at 1000
+                server-side regardless of the value passed.
+            offset: Zero-based starting index. None (default) sends no offset, which
+                ComfyUI treats as "no offset" (newest entries first).
+        """
+        params: dict[str, int] = {}
+        if max_items is not None:
+            if max_items <= 0:
+                raise ValueError("max_items must be a positive integer")
+            params["max_items"] = min(max_items, 1000)
+        if offset is not None:
+            if offset < 0:
+                raise ValueError("offset must be >= 0")
+            params["offset"] = offset
+        r = await self._request("get", "/history", params=params or None)
+        return r.json()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_client.py -v -k "test_get_history"`
+Expected: all PASS, including the pre-existing `test_get_history`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/comfyui_mcp/client.py tests/test_client.py
+git commit -m "Add optional offset to client.get_history
+
+Threads upstream /history?offset=N support through the client. The
+comfyui_get_history tool is unchanged in this PR — converting it to
+server-side paging would change the meaning of the 'total' field in
+the pagination envelope and needs separate design."
+```
+
+---
+
+## Task 6: README updates
+
+Document the new tool parameters.
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Find the existing get_image and upload_image entries in the Tools table**
+
+Run: `grep -n "comfyui_get_image\|comfyui_upload_image" README.md`
+
+The current row for `comfyui_get_image` is something like:
+```
+| `comfyui_get_image` | Download a generated image as base64 data URI, or get a direct /view URL. Params: filename, subfolder, response_format. |
+```
+
+The current row for `comfyui_upload_image` is something like:
+```
+| `comfyui_upload_image` | Upload an image to ComfyUI's input directory. Params: filename, image_data (base64), subfolder. |
+```
+
+- [ ] **Step 2: Update both rows**
+
+Locate the `comfyui_get_image` row and replace its description with:
+
+```
+| `comfyui_get_image` | Download a generated image as base64 data URI, or get a direct /view URL. Optional server-rendered thumbnail via `preview_format="webp"|"jpeg"` + `preview_quality=1-100` (only applies with `response_format="data_uri"`). |
+```
+
+Locate the `comfyui_upload_image` row and replace its description with:
+
+```
+| `comfyui_upload_image` | Upload an image to ComfyUI. Params: filename, image_data (base64), subfolder, `destination="input"|"output"|"temp"` (default input), `overwrite` (default False — ComfyUI auto-renames duplicates). |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "Document new params on comfyui_get_image and comfyui_upload_image"
+```
+
+---
+
+## Task 7: Final verification sweep
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest -v 2>&1 | tail -10`
+Expected: ALL PASS, no skipped, no errors. The count should be > 496 (the baseline before this PR) — roughly +10-12 new tests across this work.
+
+- [ ] **Step 2: Lint, format, type-check**
+
+Run: `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/comfyui_mcp/`
+Expected: clean.
+
+- [ ] **Step 3: Pre-commit on touched files**
+
+Run: `uv run pre-commit run --files $(git diff --name-only main...HEAD)`
+Expected: all hooks pass.
+
+- [ ] **Step 4: Verify the tool surface is unchanged in count**
+
+Run: `grep -rn "@mcp.tool" src/comfyui_mcp/tools/ | wc -l`
+Expected: same count as before this PR — this work only adds optional parameters to existing tools, no new tools.
+
+- [ ] **Step 5: Confirm no other tests reference the old `client.upload_image` or `client.get_image` signatures**
+
+Run: `grep -rn "client.upload_image\|client.get_image" src/ tests/ | head`
+Expected: usages match the new signatures (positional args still work — `data`, `filename`, optionally `subfolder` — and the new kwargs are keyword-only via `*`).
+
+If any verification step fails, fix and amend the appropriate commit (or add a fixup commit) before declaring the plan complete.
+
+---
+
+## Out of scope (deliberately not in this plan)
+
+- **Wire `comfyui_get_history` to use server-side offset.** Doing this changes the meaning of the pagination envelope's `total` field (it would become only the size of the returned page). Needs a separate design discussion — should `total` go away, become approximate, or be computed via an extra round-trip? Deferred.
+- **`POST /upload/mask` `type`/`overwrite` params.** The mask upload tool has the same upstream support; could extend symmetrically. Deferred for a follow-up since masks are a less common use case.
+- **`GET /view?channel=rgb|a` for mask debugging.** Niche; defer.
+- **Surfacing new `object_info` fields (`deprecated`, `experimental`, etc.) in `list_nodes`.** Audit recommendation; deferred — needs broader UX thinking about how to filter.

--- a/uv.lock
+++ b/uv.lock
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "comfyui-mcp-secure"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Small housekeeping PR to clean up session-dirty state:

- **`uv.lock`** — sync the \`comfyui-mcp-secure\` version pin to \`1.0.1\` to match \`pyproject.toml\`'s already-bumped version. Single-line lockfile change.
- **`.gitignore`** — add \`graphify-out/\` (knowledge-graph build artifacts from the \`graphify\` skill); dedupe a stray duplicate \`.full-review/\` line.
- **`docs/superpowers/plans/`** — commit the three implementation plans generated this session (jobs API, MCP best-practices cleanup, upstream API updates). PRs #69, #70, and #72 reference these files; this PR makes the references resolvable.

## Test Plan

- [x] No source code changes; no test changes; CI gates should pass mechanically.
- [x] Pre-commit hooks ran clean on the commit.