### PR TITLE
comfyui_upload_mask: destination/overwrite params + Field annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The `comfyui_download_model` tool always sends a `previewFile` field (required b
 | `comfyui_upload_image` | Upload a base64-encoded image to ComfyUI. Path-sanitized. Params: filename, image_data, subfolder, `destination="input"\|"output"\|"temp"` (default `input`), `overwrite` (default False — ComfyUI auto-renames duplicates). |
 | `comfyui_get_image` | Download a generated image. `response_format="data_uri"` (default) returns inline base64; `response_format="url"` returns a direct `/view` URL. With `data_uri`, optional `preview_format="webp"\|"jpeg"` + `preview_quality=1-100` request a server-rendered thumbnail (smaller payload, lossy). Optional `base_url_override` can override URL host per call. Path-sanitized. |
 | `comfyui_list_outputs` | List generated output filenames from history. |
-| `comfyui_upload_mask` | Upload a mask image to ComfyUI's input directory. Path-sanitized. |
+| `comfyui_upload_mask` | Upload a mask image to ComfyUI. Path-sanitized. Params: filename, mask_data, original_image, subfolder, original_subfolder, `destination="input"\|"output"\|"temp"` (default `input`), `overwrite` (default False — ComfyUI auto-renames duplicates). |
 | `comfyui_get_workflow_from_image` | Extract embedded workflow and prompt metadata from a ComfyUI-generated PNG. |
 
 ### Deliberately not exposed

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -392,11 +392,39 @@ class ComfyUIClient:
         filename: str,
         original_ref: dict[str, str],
         subfolder: str = "",
+        *,
+        destination: str = "input",
+        overwrite: bool = False,
     ) -> dict:
+        """POST /upload/mask — upload a mask image to ComfyUI.
+
+        Args:
+            data: Raw mask image bytes.
+            filename: Target filename in ComfyUI's storage.
+            original_ref: Dict identifying the original image whose alpha channel
+                this mask updates. Must include ``filename`` and ``type`` keys;
+                may include ``subfolder``.
+            subfolder: Optional subfolder within the destination.
+            destination: Destination type. One of "input" (default), "output", "temp".
+                The wire field name is ``type`` — renamed here to avoid shadowing
+                the Python builtin.
+            overwrite: If True, replace an existing file with the same name. If False
+                (default), ComfyUI auto-renames by suffixing ``(N)``.
+        """
+        if destination not in {"input", "output", "temp"}:
+            raise ValueError(
+                f"destination must be one of 'input', 'output', 'temp'; got {destination!r}"
+            )
         files = {"image": (filename, data, "image/png")}
         form_data: dict[str, str] = {"original_ref": json.dumps(original_ref)}
         if subfolder:
             form_data["subfolder"] = subfolder
+        # Only include 'type'/'overwrite' when the caller deviates from defaults —
+        # keeps the request body identical to historical behavior in the common case.
+        if destination != "input":
+            form_data["type"] = destination
+        if overwrite:
+            form_data["overwrite"] = "true"
         r = await self._request("post", "/upload/mask", files=files, data=form_data)
         return r.json()
 

--- a/src/comfyui_mcp/tools/files.py
+++ b/src/comfyui_mcp/tools/files.py
@@ -325,24 +325,50 @@ def register_file_tools(
         )
     )
     async def comfyui_upload_mask(
-        filename: str,
-        mask_data: str,
-        original_image: str,
-        subfolder: str = "",
-        original_subfolder: str = "",
+        filename: Annotated[
+            str,
+            Field(description="Name for the uploaded mask file (e.g. 'mask.png')"),
+        ],
+        mask_data: Annotated[
+            str,
+            Field(description="Base64-encoded mask image data"),
+        ],
+        original_image: Annotated[
+            str,
+            Field(
+                description="Filename of the original image the mask applies to "
+                "(must already exist in ComfyUI's input directory)"
+            ),
+        ],
+        subfolder: Annotated[
+            str,
+            Field(description="Optional subfolder for the mask file"),
+        ] = "",
+        original_subfolder: Annotated[
+            str,
+            Field(description="Optional subfolder of the original image"),
+        ] = "",
+        destination: Annotated[
+            Literal["input", "output", "temp"],
+            Field(
+                description="Destination directory. 'input' (default) is where "
+                "workflows read user-supplied masks from; 'output' and 'temp' "
+                "are usually only useful for testing or scripted setups."
+            ),
+        ] = "input",
+        overwrite: Annotated[
+            bool,
+            Field(
+                description="If True, replace any existing file with the same name. "
+                "If False (default), ComfyUI auto-renames by suffixing ' (N)'."
+            ),
+        ] = False,
     ) -> str:
-        """Upload a mask image to ComfyUI's input directory.
+        """Upload a mask image to ComfyUI.
 
         The mask's alpha channel is merged into the original image's alpha channel
         by the ComfyUI server. The original image must already exist in ComfyUI.
-
-        Args:
-            filename: Name for the uploaded mask file (e.g. 'mask.png')
-            mask_data: Base64-encoded mask image data
-            original_image: Filename of the original image the mask applies to
-                (must already exist in ComfyUI's input directory)
-            subfolder: Optional subfolder for the mask file
-            original_subfolder: Optional subfolder of the original image
+        Defaults to ComfyUI's input directory.
         """
         limiter.check("upload_mask")
         clean_name = sanitizer.validate_filename(filename)
@@ -364,11 +390,20 @@ def register_file_tools(
                 "filename": clean_name,
                 "original_image": clean_original,
                 "size_bytes": len(raw),
+                "destination": destination,
+                "overwrite": overwrite,
             },
         )
-        result = await client.upload_mask(raw, clean_name, original_ref, clean_subfolder)
+        result = await client.upload_mask(
+            raw,
+            clean_name,
+            original_ref,
+            clean_subfolder,
+            destination=destination,
+            overwrite=overwrite,
+        )
         await audit.async_log(tool="upload_mask", action="uploaded", extra={"result": result})
-        return f"Uploaded mask {result.get('name', clean_name)} to ComfyUI input directory"
+        return f"Uploaded mask {result.get('name', clean_name)} to ComfyUI {destination} directory"
 
     tool_fns["comfyui_upload_mask"] = comfyui_upload_mask
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -399,6 +399,52 @@ class TestComfyUIClient:
         assert result["name"] == "mask.png"
 
     @respx.mock
+    async def test_upload_mask_default_type(self, client):
+        # Default behavior: form does not include 'type' or 'overwrite' fields
+        route = respx.post("http://test-comfyui:8188/upload/mask").mock(
+            return_value=httpx.Response(
+                200, json={"name": "mask.png", "subfolder": "", "type": "input"}
+            )
+        )
+        await client.upload_mask(
+            b"data",
+            "mask.png",
+            {"filename": "original.png", "type": "input"},
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' not in body
+        assert b'name="overwrite"' not in body
+
+    @respx.mock
+    async def test_upload_mask_with_type_and_overwrite(self, client):
+        route = respx.post("http://test-comfyui:8188/upload/mask").mock(
+            return_value=httpx.Response(
+                200, json={"name": "mask.png", "subfolder": "", "type": "output"}
+            )
+        )
+        await client.upload_mask(
+            b"data",
+            "mask.png",
+            {"filename": "original.png", "type": "input"},
+            destination="output",
+            overwrite=True,
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' in body
+        assert b"output" in body
+        assert b'name="overwrite"' in body
+        assert b"true" in body
+
+    async def test_upload_mask_rejects_invalid_destination(self, client):
+        with pytest.raises(ValueError, match="destination"):
+            await client.upload_mask(
+                b"data",
+                "mask.png",
+                {"filename": "original.png", "type": "input"},
+                destination="garbage",
+            )
+
+    @respx.mock
     async def test_retry_on_connection_error(self, client):
         route = respx.get("http://test-comfyui:8188/queue")
         route.side_effect = [

--- a/tests/test_tools_files.py
+++ b/tests/test_tools_files.py
@@ -697,3 +697,67 @@ class TestUploadMask:
         )
         content = audit._audit_file.read_text()
         assert "upload_mask" in content
+
+
+class TestUploadMaskDestination:
+    @respx.mock
+    async def test_upload_to_output_dir(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/mask").mock(
+            return_value=httpx.Response(
+                200, json={"name": "mask.png", "subfolder": "", "type": "output"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        mask_b64 = base64.b64encode(b"data").decode()
+        result = await tools["comfyui_upload_mask"](
+            filename="mask.png",
+            mask_data=mask_b64,
+            original_image="photo.png",
+            destination="output",
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' in body
+        assert b"output" in body
+        assert "output" in result.lower()
+
+    @respx.mock
+    async def test_upload_with_overwrite(self, components):
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/mask").mock(
+            return_value=httpx.Response(
+                200, json={"name": "mask.png", "subfolder": "", "type": "input"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        mask_b64 = base64.b64encode(b"data").decode()
+        await tools["comfyui_upload_mask"](
+            filename="mask.png",
+            mask_data=mask_b64,
+            original_image="photo.png",
+            overwrite=True,
+        )
+        body = route.calls.last.request.content
+        assert b'name="overwrite"' in body
+        assert b"true" in body
+
+    @respx.mock
+    async def test_upload_default_unchanged(self, components):
+        # Verify byte-identical default-call behavior: no type or overwrite fields
+        client, audit, limiter, sanitizer = components
+        route = respx.post("http://test:8188/upload/mask").mock(
+            return_value=httpx.Response(
+                200, json={"name": "mask.png", "subfolder": "", "type": "input"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_file_tools(mcp, client, audit, limiter, sanitizer)
+        mask_b64 = base64.b64encode(b"data").decode()
+        await tools["comfyui_upload_mask"](
+            filename="mask.png", mask_data=mask_b64, original_image="photo.png"
+        )
+        body = route.calls.last.request.content
+        assert b'name="type"' not in body
+        assert b'name="overwrite"' not in body


### PR DESCRIPTION
## Summary

Two follow-ups to PR #72 and the original best-practices audit, bundled into one small PR:

- **Symmetric `destination`/`overwrite` params on `comfyui_upload_mask`** — mirrors what PR #72 did for `comfyui_upload_image` (Copilot's review of #72 flagged this as a deferred follow-up). ComfyUI's `/upload/mask` accepts the same upstream params via the shared `image_upload` helper.
- **Field annotation migration** — five existing params (`filename`, `mask_data`, `original_image`, `subfolder`, `original_subfolder`) move from bare types to `Annotated[..., Field(description=...)]`, satisfying CLAUDE.md rule 13 (3+ params). This was the last upload tool with rule-13 drift; the audit's "Important #6" is now closed.

Default behavior is byte-identical: when callers don't pass the new kwargs, the form body has no `type` or `overwrite` fields (test `test_upload_default_unchanged` is the regression guard). Defense-in-depth: `destination` is enforced by pydantic `Literal["input", "output", "temp"]` at the FastMCP boundary AND by a runtime check in `client.upload_mask`.

## Test Plan

- [x] `uv run pytest` — 518 passed (+6 new tests over main's 512)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/comfyui_mcp/` — no issues
- [x] Sanitizer/audit/rate-limit still applied in `comfyui_upload_mask` closure (security invariants unchanged)
- [ ] Smoke test against a live ComfyUI: `comfyui_upload_mask(..., destination="output")` and `overwrite=True` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)