### PR TITLE
Phase 4 evaluation suite + fix txt2vid summarize crash

### DIFF
--- a/evals/2026-05-11-comfyui-mcp-v1.xml
+++ b/evals/2026-05-11-comfyui-mcp-v1.xml
@@ -1,0 +1,42 @@
+<evaluation>
+   <qa_pair>
+      <question>Generate a workflow from the built-in flux_txt2img template using its defaults, then generate one from the txt2img template, then from the sdxl_txt2img template. Summarize each in text format. Of these three workflows, which template name has the lowest default classifier-free-guidance value reported in the summary's Parameters line? Respond with the template name exactly as it appears in the template list.</question>
+      <answer>flux_txt2img</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Build a workflow from the built-in sdxl_txt2img template using its defaults, then summarize it in text format. What integer value of the latent image width appears in the summary's Parameters line?</question>
+      <answer>1024</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Generate workflows from both the built-in upscale template and the built-in face_restore template using their defaults, then summarize each in text format. Both summaries report the same value on the "Pipeline:" line. What is that pipeline string?</question>
+      <answer>img2img -&gt; upscale</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Fetch the recommended generation presets for the Flux model family and for the Stable Diffusion 1.5 model family. Add together the recommended "steps" value from each. What is the sum?</question>
+      <answer>48</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Compare the recommended generation presets for the SD3 and SDXL model families. Which of those two families recommends the "sgm_uniform" scheduler? Answer with the family identifier exactly as the tool reports it (e.g. sd15, sdxl, flux, sd3, cascade).</question>
+      <answer>sd3</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Retrieve the prompting guide for the SDXL model family and the prompting guide for the SD3 model family. How many entries are in the "quality_tags" list of the SDXL guide?</question>
+      <answer>3</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Start from a fresh workflow built from the built-in txt2img template with default parameters. Apply a batch of modifications that (1) sets the KSampler node's steps input to 50, (2) sets the KSampler node's cfg input to 8.5, and (3) appends a new LoraLoader node (let the modifier assign its id automatically). Summarize the resulting workflow in text format. What integer node count does the summary report?</question>
+      <answer>8</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Start from the built-in txt2img template with default parameters. Modify it by setting the "samples" input of the VAEDecode node (id "6") to reference a non-existent source node with id "99". Validate the resulting workflow. Does the validator report the workflow as valid? Answer true or false.</question>
+      <answer>false</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Generate the default workflows for each of the three built-in ControlNet templates (canny, depth, openpose). Inspect the preprocessor node in each one. Which of the three templates uses the "DWPreprocessor" class_type as its preprocessor? Answer with the template name exactly as it appears in the template list.</question>
+      <answer>controlnet_openpose</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Build the default workflow from the built-in inpaint template and the default workflow from the built-in lora_stack template, then summarize each in text format. Subtract the lora_stack node count from the inpaint node count. What is the difference?</question>
+      <answer>1</answer>
+   </qa_pair>
+</evaluation>

--- a/evals/2026-05-11-report-gpt-oss-120b-v2.md
+++ b/evals/2026-05-11-report-gpt-oss-120b-v2.md
@@ -1,0 +1,312 @@
+# Evaluation Report (Ollama)
+
+- **Model**: `gpt-oss:120b-cloud`
+- **Accuracy**: 8/10 (80.0%)
+- **Average task duration**: 22.03s
+- **Average tool calls per task**: 2.50
+- **Total tool calls**: 25
+
+---
+
+
+### Task 1
+
+**Question**: Generate a workflow from the built-in flux_txt2img template using its defaults, then generate one from the txt2img template, then from the sdxl_txt2img template. Summarize each in text format. Of these three workflows, which template name has the lowest default classifier-free-guidance value reported in the summary's Parameters line? Respond with the template name exactly as it appears in the template list.
+**Expected**: `flux_txt2img`
+**Actual**: `flux_txt2img`
+**Correct**: ✅
+**Duration**: 33.52s
+**Tool calls** (4): comfyui_create_workflow×4
+
+**Summary**
+
+1. Used `comfyui_create_workflow` three times with templates `flux_txt2img`, `txt2img`, and `sdxl_txt2img`, each with empty parameters to get default workflows.
+2. Parsed each returned workflow JSON to extract the default classifier‑free guidance (`cfg`) values:
+   - flux_txt2img: cfg = 1.0
+   - txt2img: cfg = 7.0
+   - sdxl_txt2img: cfg = 6.0
+3. Compared the cfg values and identified the smallest one as belonging to the `flux_txt2img` template.
+4. Summarized the workflow details (model, dimensions, steps, cfg) for each template (as described in the previous answer).
+
+**Feedback**
+
+**Tool Names:** Descriptive and aligned with their actions (e.g., `comfyui_create_workflow`).
+**Input Parameters:** Clearly documented; required fields (`template`) and optional (`params`). The need to supply an empty JSON string `{}` for defaults is a bit unintuitive—allowing omission of `params` could improve usability.
+**Descriptions:** Accurately explain functionality. The error message when providing an empty string highlighted that `params` must be valid JSON; a note in the description about this requirement would prevent confusion.
+**Overall:** The tools performed as expected; no errors after providing proper JSON. Minor documentation tweak (optional params handling) would enhance developer experience.
+
+---
+
+
+### Task 2
+
+**Question**: Build a workflow from the built-in sdxl_txt2img template using its defaults, then summarize it in text format. What integer value of the latent image width appears in the summary's Parameters line?
+**Expected**: `1024`
+**Actual**: `1024`
+**Correct**: ✅
+**Duration**: 16.59s
+**Tool calls** (3): comfyui_create_workflow×2, comfyui_summarize_workflow×1
+
+**Summary**
+
+1. Created a workflow from the built-in `sdxl_txt2img` template using `comfyui_create_workflow` with empty parameters to obtain the default workflow JSON.
+2. Passed the returned workflow JSON to `comfyui_summarize_workflow` with `output_format` set to `"text"` to get a human‑readable summary.
+3. Extracted the **Parameters** line from the summary, which lists `width=1024, height=1024, …`.
+4. Identified the integer value for the latent image width as **1024**.
+
+**Feedback**
+
+- **Tool names** are clear and descriptive (e.g., `comfyui_create_workflow`, `comfyui_summarize_workflow`), making it easy to understand their purpose.
+- **Input parameters** are well‑documented, but distinguishing required vs. optional could be clearer (e.g., marking `params` as optional when using defaults).
+- **Descriptions** accurately reflect functionality, though the `comfyui_create_workflow` description could explicitly note that an empty JSON `{}` can be used for defaults.
+- No errors were encountered during tool usage.
+- **Improvement suggestions:**
+  1. Add an explicit `required` flag for each parameter in the documentation to avoid ambiguity.
+  2. Provide example usage for optional JSON strings (like `params`) to guide users on valid empty inputs.
+  3. Include a short “notes” field for edge cases, such as needing `{}` instead of an empty string for JSON parameters.
+
+---
+
+
+### Task 3
+
+**Question**: Generate workflows from both the built-in upscale template and the built-in face_restore template using their defaults, then summarize each in text format. Both summaries report the same value on the "Pipeline:" line. What is that pipeline string?
+**Expected**: `img2img -> upscale`
+**Actual**: `(no <response>)`
+**Correct**: ❌
+**Duration**: 9.52s
+**Tool calls** (0): —
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 4
+
+**Question**: Fetch the recommended generation presets for the Flux model family and for the Stable Diffusion 1.5 model family. Add together the recommended "steps" value from each. What is the sum?
+**Expected**: `48`
+**Actual**: `48`
+**Correct**: ✅
+**Duration**: 18.84s
+**Tool calls** (2): comfyui_get_model_presets×2
+
+**Summary**
+
+- Retrieved recommended presets for Flux model family using `comfyui_get_model_presets`; obtained steps = 20.
+- Retrieved recommended presets for Stable Diffusion 1.5 (sd15) model family using the same tool; obtained steps = 28.
+- Calculated sum: 20 + 28 = 48.
+
+**Feedback**
+
+- **Tool Naming:** `comfyui_get_model_presets` is clear and descriptive.
+- **Input Parameters:** Documentation mentions both `model_family` (required) and `model_name` (optional). Clarifying required vs optional in the docstring would improve usability.
+- **Description Accuracy:** Accurately describes purpose. Including example families (e.g., flux, sd15) could help discoverability.
+- **Response Structure:** The tool returns a nested object with a `family` key and a `recommended` sub‑object. The nesting is useful but could be simplified (e.g., return only the `recommended` object) if callers only need those settings.
+- **Error Handling:** No errors encountered during calls.
+- **Suggested Improvements:**
+  1. Explicitly label `model_family` as required in docs.
+  2. Provide a concise schema for the returned JSON (required fields like `steps`).
+  3. Consider flattening the response to avoid redundant nesting.
+
+---
+
+
+### Task 5
+
+**Question**: Compare the recommended generation presets for the SD3 and SDXL model families. Which of those two families recommends the "sgm_uniform" scheduler? Answer with the family identifier exactly as the tool reports it (e.g. sd15, sdxl, flux, sd3, cascade).
+**Expected**: `sd3`
+**Actual**: `sd3`
+**Correct**: ✅
+**Duration**: 11.69s
+**Tool calls** (2): comfyui_get_model_presets×2
+
+**Summary**
+
+To determine which model family recommends the "sgm_uniform" scheduler, I called comfyui_get_model_presets twice: first with model_family="sd3" and then with model_family="sdxl". The SD3 response showed "scheduler": "sgm_uniform", while the SDXL response showed "scheduler": "karras". Thus, only the SD3 family recommends "sgm_uniform".
+
+**Feedback**
+
+Tool names are clear (e.g., comfyui_get_model_presets) and the purpose is obvious. Input parameters are well‑documented; model_family is required, model_name optional. The description accurately reflects the output (recommended settings). No errors occurred, but the response could explicitly note that model_name is optional and defaults to null.
+
+---
+
+
+### Task 6
+
+**Question**: Retrieve the prompting guide for the SDXL model family and the prompting guide for the SD3 model family. How many entries are in the "quality_tags" list of the SDXL guide?
+**Expected**: `3`
+**Actual**: `3`
+**Correct**: ✅
+**Duration**: 20.31s
+**Tool calls** (2): comfyui_get_prompting_guide×2
+
+**Summary**
+
+- Retrieved the prompting guide for the SDXL model family using `comfyui_get_prompting_guide` (model_family="sdxl").
+- Retrieved the prompting guide for the SD3 model family using the same tool (model_family="sd3").
+- Examined the `quality_tags` array in the SDXL guide, which contained three items: "cinematic lighting", "high detail", and "sharp focus".
+- Determined that the number of entries in the SDXL `quality_tags` list is 3.
+
+**Feedback**
+
+- **Tool Names:** The names are clear and descriptive, indicating their purpose (e.g., `comfyui_get_prompting_guide` clearly fetches a prompting guide).
+- **Input Parameters:** Parameters are well documented; required parameters are evident. Explicitly marking required vs optional in the documentation would improve clarity.
+- **Descriptions:** The tool descriptions accurately convey functionality, making it easy to understand what each tool does.
+- **Usability:** The JSON responses are straightforward, allowing easy extraction of needed fields without additional parsing complexity.
+- **Improvement Suggestions:** Providing a formal schema for the returned guide (e.g., guaranteeing the presence of `quality_tags` as a list) would help developers write more robust code.
+
+---
+
+
+### Task 7
+
+**Question**: Start from a fresh workflow built from the built-in txt2img template with default parameters. Apply a batch of modifications that (1) sets the KSampler node's steps input to 50, (2) sets the KSampler node's cfg input to 8.5, and (3) appends a new LoraLoader node (let the modifier assign its id automatically). Summarize the resulting workflow in text format. What integer node count does the summary report?
+**Expected**: `8`
+**Actual**: `8`
+**Correct**: ✅
+**Duration**: 37.63s
+**Tool calls** (4): comfyui_create_workflow×1, comfyui_modify_workflow×2, comfyui_summarize_workflow×1
+
+**Summary**
+
+Steps taken:
+1. Created a fresh txt2img workflow using **comfyui_create_workflow** with the default template.
+2. Modified the workflow with **comfyui_modify_workflow**:
+   - Set KSampler node (id 5) steps to 50.
+   - Set KSampler node cfg to 8.5.
+   - Added a new LoraLoader node (automatically assigned id 8).
+3. Summarized the resulting workflow using **comfyui_summarize_workflow** in text format, which returned a concise description and reported the node count.
+
+The summary indicated the workflow now contains **8 nodes**.
+
+Resulting integer node count: **8**.
+
+**Feedback**
+
+Tool names are clear and descriptive overall (e.g., `comfyui_create_workflow`, `comfyui_modify_workflow`). The modify tool requires specific field names (`input_name` instead of just `input`), which caused an initial error; documentation could emphasize this requirement more prominently. Parameter documentation is generally good, but distinguishing required vs optional could be clearer (e.g., `operations` is required, but its internal fields vary per operation). The error messages are helpful but could include suggestions for correct field names. Overall the tools work well, but adding a quick‑reference for operation payload structures would reduce trial‑and‑error.
+
+---
+
+
+### Task 8
+
+**Question**: Start from the built-in txt2img template with default parameters. Modify it by setting the "samples" input of the VAEDecode node (id "6") to reference a non-existent source node with id "99". Validate the resulting workflow. Does the validator report the workflow as valid? Answer true or false.
+**Expected**: `false`
+**Actual**: `false`
+**Correct**: ✅
+**Duration**: 20.58s
+**Tool calls** (3): comfyui_create_workflow×1, comfyui_modify_workflow×1, comfyui_validate_workflow×1
+
+**Summary**
+
+1. Created a default txt2img workflow using **comfyui_create_workflow** with template "txt2img". Received the base workflow JSON.
+2. Modified the workflow using **comfyui_modify_workflow** to set the "samples" input of node "6" (VAEDecode) to reference node "99". The operation succeeded and returned the updated workflow JSON.
+3. Validated the modified workflow with **comfyui_validate_workflow**. The validator returned `"valid": false` with an error stating that node '6' input 'samples' references a non‑existent node '99'.
+4. Determined that the validator does **not** consider the workflow valid.
+
+**Feedback**
+
+- **Tool names**: Generally clear (e.g., `comfyui_create_workflow`, `comfyui_modify_workflow`, `comfyui_validate_workflow`). The “modify” tool could mention that it expects a JSON string for both workflow and operations to avoid confusion.
+- **Input parameters**: Descriptions are adequate, but explicitly marking required vs optional would help (e.g., `operations` is required). For `comfyui_modify_workflow`, clarifying that `operations` must be a JSON‑encoded array improves usability.
+- **Descriptions**: Accurate overall. Adding example snippets for common operations (like `set_input`) would make the tools more approachable.
+- **Errors**: No errors encountered during usage.
+- **Improvements**: Include a short note in `comfyui_validate_workflow` docs about the structure of the returned error list, so callers know how to interpret failures.
+
+---
+
+
+### Task 9
+
+**Question**: Generate the default workflows for each of the three built-in ControlNet templates (canny, depth, openpose). Inspect the preprocessor node in each one. Which of the three templates uses the "DWPreprocessor" class_type as its preprocessor? Answer with the template name exactly as it appears in the template list.
+**Expected**: `controlnet_openpose`
+**Actual**: `controlnet_openpose`
+**Correct**: ✅
+**Duration**: 21.65s
+**Tool calls** (3): comfyui_create_workflow×3
+
+**Summary**
+
+I called `comfyui_create_workflow` for each of the three built‑in ControlNet templates: `controlnet_canny`, `controlnet_depth`, and `controlnet_openpose`.
+- In the Canny workflow, node 3 was `CannyEdgePreprocessor`.
+- In the Depth workflow, node 3 was `MiDaS-DepthMapPreprocessor`.
+- In the OpenPose workflow, node 3 was `DWPreprocessor`.
+
+Comparing these, only the OpenPose template uses the `DWPreprocessor` class_type. I therefore identified the template name exactly as it appears in the list: **controlnet_openpose**.
+
+**Feedback**
+
+**Tool names:** The `comfyui_create_workflow` name clearly indicates it creates a workflow, which is appropriate.
+**Input parameters:** The `template` and `params` fields are well‑documented; it’s clear which are required. The optional `params` JSON can be empty as shown.
+**Descriptions:** The tool description accurately describes returning a default workflow JSON. No issues encountered.
+**Improvements:**
+- It would be helpful if the response also included a brief schema or example of the returned workflow for easier downstream parsing.
+- Adding a parameter to directly request only specific nodes (e.g., preprocessor) could reduce data transfer for use cases like this.
+Overall, the tools functioned as expected.
+
+---
+
+
+### Task 10
+
+**Question**: Build the default workflow from the built-in inpaint template and the default workflow from the built-in lora_stack template, then summarize each in text format. Subtract the lora_stack node count from the inpaint node count. What is the difference?
+**Expected**: `1`
+**Actual**: `**Workflow Summaries**
+
+*Inpaint (default)*
+1. Load checkpoint (v1‑5‑pruned‑emaonly).
+2. Load input image (`input.png`).
+3. Load mask image (`mask.png`) as alpha channel.
+4. Encode the image to latent space (VAEEncode).
+5. Apply the mask to the latent (SetLatentNoiseMask).
+6. Encode positive prompt (empty) via CLIP.
+7. Encode negative prompt ("bad quality, blurry") via CLIP.
+8. Sample with KSampler (steps 20, cfg 7.0, denoise 0.8).
+9. Decode latent to image (VAEDecode).
+10. Save the result (`comfyui-mcp-inpaint`).
+
+*Lora Stack (default)*
+1. Load checkpoint (v1‑5‑pruned‑ema‑only).
+2. Load first LoRA (`detail‑tweaker.safetensors`) onto model and CLIP (strength 0.75).
+3. Load second LoRA (`style‑cinematic.safetensors`) onto the result of step 2 (strength 0.45).
+4. Encode positive prompt (empty) via CLIP.
+5. Encode negative prompt ("bad quality, blurry") via CLIP.
+6. Create an empty latent image (768×768).
+7. Sample with KSampler (steps 24, cfg 6.5, denoise 1.0) using the LoRA‑modified model.
+8. Decode latent to image (VAEDecode).
+9. Save the result (`comfyui-mcp-lora-stack`).
+
+**Node Count Difference**
+Inpaint workflow nodes: 10
+Lora_stack workflow nodes: 9
+
+**Difference (Inpaint – Lora_stack) = 1**`
+**Correct**: ❌
+**Duration**: 30.00s
+**Tool calls** (2): comfyui_create_workflow×2
+
+**Summary**
+
+- Used **comfyui_create_workflow** with template='inpaint' to obtain the default inpaint workflow (10 nodes).
+- Used **comfyui_create_workflow** with template='lora_stack' to obtain the default lora_stack workflow (9 nodes).
+- Counted nodes in each workflow:
+  * Inpaint workflow nodes: CheckpointLoaderSimple, LoadImage, LoadImageMask, VAEEncode, SetLatentNoiseMask, CLIPTextEncode (positive), CLIPTextEncode (negative), KSampler, VAEDecode, SaveImage → **10 nodes**.
+  * Lora_stack workflow nodes: CheckpointLoaderSimple, LoraLoader (detail‑tweaker), LoraLoader (style‑cinematic), CLIPTextEncode (positive), CLIPTextEncode (negative), EmptyLatentImage, KSampler, VAEDecode, SaveImage → **9 nodes**.
+- Calculated difference: 10 – 9 = **1**.
+- Summarized each workflow in plain text (see response).
+
+**Feedback**
+
+- **Tool naming**: Clear and descriptive; *comfyui_create_workflow* directly conveys its purpose.
+- **Input parameters**: Well‑documented; required parameters (`template`, `params`) are evident. Optional overrides are clearly optional via the `params` JSON string.
+- **Descriptions**: Accurate and helpful, explaining expected JSON structure and return values.
+- **Usage**: No errors were encountered; tools performed as expected.
+- **Improvement suggestion**: Provide a dedicated tool (e.g., `comfyui_list_builtin_templates`) to list available built‑in templates, making discovery easier without external docs.
+
+---

--- a/evals/2026-05-11-report-gpt-oss-120b.md
+++ b/evals/2026-05-11-report-gpt-oss-120b.md
@@ -1,0 +1,270 @@
+# Evaluation Report (Ollama)
+
+- **Model**: `gpt-oss:120b-cloud`
+- **Accuracy**: 4/10 (40.0%)
+- **Average task duration**: 17.69s
+- **Average tool calls per task**: 3.20
+- **Total tool calls**: 32
+
+---
+
+
+### Task 1
+
+**Question**: Generate a workflow from the built-in flux_txt2img template using its defaults, then generate one from the txt2img template, then from the sdxl_txt2img template. Summarize each in text format. Of these three workflows, which template name has the lowest default classifier-free-guidance value reported in the summary's Parameters line? Respond with the template name exactly as it appears in the template list.
+**Expected**: `flux_txt2img`
+**Actual**: `**Workflow Summaries**
+
+**flux_txt2img**
+- **Model:** flux1-dev.safetensors
+- **Size:** 1024 × 1024
+- **Steps:** 20
+- **CFG:** 1.0
+- **Sampler:** euler
+- **Scheduler:** simple
+- **Negative Prompt:** “low quality, artifacts”
+
+**txt2img**
+- **Model:** v1-5-pruned-emaonly.safetensors
+- **Size:** 512 × 512
+- **Steps:** 20
+- **CFG:** 7.0
+- **Sampler:** euler
+- **Scheduler:** normal
+- **Negative Prompt:** “bad quality, blurry”
+
+**sdxl_txt2img**
+- **Model:** sd_xl_base_1.0.safetensors
+- **Size:** 1024 × 1024
+- **Steps:** 30
+- **CFG:** 6.0
+- **Sampler:** dpmpp_2m
+- **Scheduler:** karras
+- **Negative Prompt:** “bad quality, blurry”
+
+**Template with the lowest default classifier‑free guidance:**
+flux_txt2img`
+**Correct**: ❌
+**Duration**: 22.16s
+**Tool calls** (4): comfyui_create_workflow×4
+
+**Summary**
+
+1. Used **comfyui_create_workflow** three times to generate the default workflows for the templates **flux_txt2img**, **txt2img**, and **sdxl_txt2img**.
+2. Extracted key parameters from each workflow JSON:
+   - Model checkpoint (ckpt_name)
+   - Image dimensions (width, height)
+   - Sampling steps
+   - Classifier‑free guidance (cfg)
+   - Sampler name
+   - Scheduler
+   - Negative prompt text
+3. Built concise textual summaries for each workflow, listing the above parameters.
+4. Compared the `cfg` values:
+   - flux_txt2img: **1.0**
+   - txt2img: **7.0**
+   - sdxl_txt2img: **6.0**
+5. Determined that the lowest default CFG is in the **flux_txt2img** workflow.
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 2
+
+**Question**: Build a workflow from the built-in sdxl_txt2img template using its defaults, then summarize it in text format. What integer value of the latent image width appears in the summary's Parameters line?
+**Expected**: `1024`
+**Actual**: `1024`
+**Correct**: ✅
+**Duration**: 13.65s
+**Tool calls** (2): comfyui_create_workflow×1, comfyui_summarize_workflow×1
+
+**Summary**
+
+I first used the **comfyui_create_workflow** tool with the template “sdxl_txt2img” and default parameters to generate the full workflow JSON.
+Next, I passed this workflow JSON to **comfyui_summarize_workflow** with `output_format: "text"` to obtain a human‑readable summary.
+The summary’s “Parameters” line lists `width=1024`.
+Thus, the integer value of the latent image width is **1024**.
+
+**Feedback**
+
+- Tool names are clear and indicate their purpose (e.g., `comfyui_create_workflow`, `comfyui_summarize_workflow`).
+- Input parameters are well‑documented; required fields like `template` or `workflow` are obvious, and optional fields are described.
+- Descriptions accurately reflect functionality.
+- No errors were encountered during usage.
+- Suggest adding examples in the documentation for composite tools (e.g., `comfyui_summarize_workflow`) to illustrate expected JSON format, which would aid users unfamiliar with the workflow schema.
+
+---
+
+
+### Task 3
+
+**Question**: Generate workflows from both the built-in upscale template and the built-in face_restore template using their defaults, then summarize each in text format. Both summaries report the same value on the "Pipeline:" line. What is that pipeline string?
+**Expected**: `img2img -> upscale`
+**Actual**: `img2img -> upscale`
+**Correct**: ✅
+**Duration**: 30.10s
+**Tool calls** (6): comfyui_create_workflow×3, comfyui_summarize_workflow×3
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 4
+
+**Question**: Fetch the recommended generation presets for the Flux model family and for the Stable Diffusion 1.5 model family. Add together the recommended "steps" value from each. What is the sum?
+**Expected**: `48`
+**Actual**: `(no <response>)`
+**Correct**: ❌
+**Duration**: 6.16s
+**Tool calls** (2): comfyui_get_model_presets×2
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 5
+
+**Question**: Compare the recommended generation presets for the SD3 and SDXL model families. Which of those two families recommends the "sgm_uniform" scheduler? Answer with the family identifier exactly as the tool reports it (e.g. sd15, sdxl, flux, sd3, cascade).
+**Expected**: `sd3`
+**Actual**: `(no <response>)`
+**Correct**: ❌
+**Duration**: 11.88s
+**Tool calls** (2): comfyui_get_model_presets×2
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 6
+
+**Question**: Retrieve the prompting guide for the SDXL model family and the prompting guide for the SD3 model family. How many entries are in the "quality_tags" list of the SDXL guide?
+**Expected**: `3`
+**Actual**: `(no <response>)`
+**Correct**: ❌
+**Duration**: 8.27s
+**Tool calls** (2): comfyui_get_prompting_guide×2
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 7
+
+**Question**: Start from a fresh workflow built from the built-in txt2img template with default parameters. Apply a batch of modifications that (1) sets the KSampler node's steps input to 50, (2) sets the KSampler node's cfg input to 8.5, and (3) appends a new LoraLoader node (let the modifier assign its id automatically). Summarize the resulting workflow in text format. What integer node count does the summary report?
+**Expected**: `8`
+**Actual**: `8`
+**Correct**: ✅
+**Duration**: 40.37s
+**Tool calls** (5): comfyui_create_workflow×1, comfyui_modify_workflow×3, comfyui_summarize_workflow×1
+
+**Summary**
+
+- Started by creating a fresh txt2img workflow using **comfyui_create_workflow** with the built‑in template.
+- Modified the workflow with **comfyui_modify_workflow**:
+  1. Set KSampler node (5) steps to 50.
+  2. Set KSampler node (5) cfg to 8.5.
+  3. Added a new **LoraLoader** node, automatically assigned id 8.
+- Summarized the resulting workflow using **comfyui_summarize_workflow** in text format.
+- The summary reported the workflow contains **8 nodes**.
+
+**Feedback**
+
+- Tool names are generally clear (e.g., `comfyui_create_workflow`, `comfyui_modify_workflow`), but some could be more intuitive: `comfyui_modify_workflow` could mention “batch edit” in its name for clarity.
+- Input parameters documentation is good, but required vs optional flags are sometimes ambiguous. For `modify_workflow`, the required field `node_id` vs `node` caused initial errors; clearer docs specifying exact field names would reduce trial‑and‑error.
+- Descriptions accurately convey functionality, though the error messages from the API (e.g., “set_input requires a non‑empty string 'input_name'”) highlight that parameter naming is strict; adding examples in the docstrings would help users.
+- No functional errors after correcting parameter names; overall the tools performed well.
+- Suggest adding a validation step or helper that lists available node IDs before modification, to avoid mismatches.
+
+---
+
+
+### Task 8
+
+**Question**: Start from the built-in txt2img template with default parameters. Modify it by setting the "samples" input of the VAEDecode node (id "6") to reference a non-existent source node with id "99". Validate the resulting workflow. Does the validator report the workflow as valid? Answer true or false.
+**Expected**: `false`
+**Actual**: `(no <response>)`
+**Correct**: ❌
+**Duration**: 12.56s
+**Tool calls** (2): comfyui_create_workflow×1, comfyui_validate_workflow×1
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 9
+
+**Question**: Generate the default workflows for each of the three built-in ControlNet templates (canny, depth, openpose). Inspect the preprocessor node in each one. Which of the three templates uses the "DWPreprocessor" class_type as its preprocessor? Answer with the template name exactly as it appears in the template list.
+**Expected**: `controlnet_openpose`
+**Actual**: `(no <response>)`
+**Correct**: ❌
+**Duration**: 20.72s
+**Tool calls** (5): comfyui_list_workflows×2, comfyui_create_workflow×3
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---
+
+
+### Task 10
+
+**Question**: Build the default workflow from the built-in inpaint template and the default workflow from the built-in lora_stack template, then summarize each in text format. Subtract the lora_stack node count from the inpaint node count. What is the difference?
+**Expected**: `1`
+**Actual**: `1`
+**Correct**: ✅
+**Duration**: 11.07s
+**Tool calls** (2): comfyui_create_workflow×2
+
+**Summary**
+
+(no summary)
+
+**Feedback**
+
+(no feedback)
+
+---

--- a/scripts/run_eval_ollama.py
+++ b/scripts/run_eval_ollama.py
@@ -1,0 +1,391 @@
+"""MCP eval harness that runs questions against an Ollama-served model.
+
+Mirrors the structure of `mcp-builder`'s `scripts/evaluation.py` but uses Ollama's
+OpenAI-style tool-use API instead of Anthropic. Useful when you want to test the
+MCP server's tool descriptions/schemas against open-weight or Ollama-cloud models.
+
+Usage:
+
+    uv run --with ollama --with mcp python scripts/run_eval_ollama.py \\
+        --model gpt-oss:120b-cloud \\
+        --eval evals/2026-05-11-comfyui-mcp-v1.xml \\
+        --output evals/2026-05-11-report.md \\
+        -c .venv/bin/python -a -m comfyui_mcp.server \\
+        -e COMFYUI_URL=http://localhost:8188
+
+Requires:
+- Ollama daemon running locally (`ollama serve`).
+- For *-cloud models: be signed in (`ollama signin` if needed) so the daemon can
+  proxy cloud inference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import shlex
+import sys
+import time
+import traceback
+import xml.etree.ElementTree as ET
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from ollama import AsyncClient as OllamaAsyncClient
+
+EVALUATION_PROMPT = """You are an AI assistant with access to tools.
+
+When given a task, you MUST:
+1. Use the available tools to complete the task
+2. Provide summary of each step in your approach, wrapped in <summary> tags
+3. Provide feedback on the tools provided, wrapped in <feedback> tags
+4. Provide your final response, wrapped in <response> tags
+
+Summary Requirements:
+- In your <summary> tags, you must explain:
+  - The steps you took to complete the task
+  - Which tools you used, in what order, and why
+  - The inputs you provided to each tool
+  - The outputs you received from each tool
+  - A summary for how you arrived at the response
+
+Feedback Requirements:
+- In your <feedback> tags, provide constructive feedback on the tools:
+  - Comment on tool names: Are they clear and descriptive?
+  - Comment on input parameters: Are they well-documented?
+    Are required vs optional parameters clear?
+  - Comment on descriptions: Do they accurately describe what the tool does?
+  - Comment on any errors encountered during tool usage.
+  - Identify specific areas for improvement and explain WHY they would help.
+  - Be specific and actionable in your suggestions.
+
+Response Requirements:
+- Your response should be concise and directly address what was asked.
+- Always wrap your final response in <response> tags.
+- If you cannot solve the task return <response>NOT_FOUND</response>.
+- For numeric responses, provide just the number.
+- For names or text, provide the exact text requested.
+- Your response should go last."""
+
+
+def parse_evaluation_file(path: Path) -> list[dict[str, str]]:
+    # S314 rationale: this script only ever reads eval XML files we author and
+    # commit ourselves; there is no untrusted-input attack surface here.
+    tree = ET.parse(path)  # noqa: S314
+    root = tree.getroot()
+    out: list[dict[str, str]] = []
+    for qa in root.findall(".//qa_pair"):
+        q = qa.find("question")
+        a = qa.find("answer")
+        if q is not None and a is not None:
+            out.append({"question": (q.text or "").strip(), "answer": (a.text or "").strip()})
+    return out
+
+
+def extract_xml_content(text: str | None, tag: str) -> str | None:
+    if not text:
+        return None
+    matches = re.findall(rf"<{tag}>(.*?)</{tag}>", text, re.DOTALL)
+    return matches[-1].strip() if matches else None
+
+
+_MD_STRIPPER = re.compile(r"^[\s>*_`#\-]+|[\s>*_`#\-]+$")
+
+
+def extract_response_with_fallback(text: str | None) -> str | None:
+    """Return the <response> contents if present, else the last meaningful line.
+
+    Many OSS models (e.g. gpt-oss-cloud) don't reliably emit XML wrappers even
+    when the system prompt requires them. As a defense, we fall back to the
+    last non-empty line of the assistant text, stripped of trailing/leading
+    markdown decoration (bold, blockquote, bullets, backticks, headers, etc.).
+    """
+    primary = extract_xml_content(text, "response")
+    if primary is not None:
+        return primary
+    if not text:
+        return None
+    lines = [_MD_STRIPPER.sub("", line).strip() for line in text.splitlines()]
+    lines = [line for line in lines if line]
+    return lines[-1] if lines else None
+
+
+def mcp_tools_to_ollama(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert MCP `inputSchema` tool defs to Ollama/OpenAI function-tool defs."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t["name"],
+                "description": (t.get("description") or "")[:1024],
+                "parameters": t["input_schema"],
+            },
+        }
+        for t in tools
+    ]
+
+
+async def call_tool_safely(session: ClientSession, name: str, args: dict[str, Any]) -> str:
+    """Call an MCP tool and return its content as a string."""
+    try:
+        result = await session.call_tool(name, arguments=args)
+        # result.content is a list of TextContent / ImageContent / EmbeddedResource
+        chunks: list[str] = []
+        for block in result.content or []:
+            if hasattr(block, "text"):
+                chunks.append(block.text)
+            else:
+                chunks.append(repr(block))
+        return "\n".join(chunks) if chunks else "(empty)"
+    except Exception as e:
+        return f"Error executing tool {name}: {e}\n{traceback.format_exc()}"
+
+
+_NUDGE_PROMPT = (
+    "Based on the tool results above, provide your final answer now. "
+    "It MUST be wrapped in <response>...</response> tags (plus <summary> and "
+    "<feedback>) as instructed. Do not call any more tools."
+)
+
+
+async def agent_loop(
+    client: OllamaAsyncClient,
+    model: str,
+    question: str,
+    ollama_tools: list[dict[str, Any]],
+    session: ClientSession,
+    max_iterations: int = 30,
+) -> tuple[str, dict[str, dict[str, Any]]]:
+    """Run an Ollama tool-use agent loop until the model produces a non-tool response."""
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": EVALUATION_PROMPT},
+        {"role": "user", "content": question},
+    ]
+    tool_metrics: dict[str, dict[str, Any]] = {}
+    nudged = False
+
+    for _ in range(max_iterations):
+        response = await client.chat(model=model, messages=messages, tools=ollama_tools)
+        msg = response["message"]
+        content = msg.get("content") or ""
+        tool_calls = msg.get("tool_calls") or []
+
+        # Preserve the assistant turn (including any tool_calls) for the next round.
+        assistant_turn: dict[str, Any] = {"role": "assistant", "content": content}
+        if tool_calls:
+            assistant_turn["tool_calls"] = tool_calls
+        messages.append(assistant_turn)
+
+        if not tool_calls:
+            # Final answer turn. Many OSS models terminate after the tool calls
+            # with an empty or unwrapped reply. Nudge once asking them to emit
+            # the required <response> wrapper, then accept whatever comes back.
+            if not nudged and ("<response>" not in content):
+                nudged = True
+                messages.append({"role": "user", "content": _NUDGE_PROMPT})
+                continue
+            return content, tool_metrics
+
+        for tc in tool_calls:
+            fn = tc.get("function") or {}
+            name = fn.get("name", "")
+            raw_args = fn.get("arguments") or {}
+            args = raw_args if isinstance(raw_args, dict) else json.loads(raw_args)
+
+            t0 = time.time()
+            tool_response = await call_tool_safely(session, name, args)
+            dt = time.time() - t0
+
+            bucket = tool_metrics.setdefault(name, {"count": 0, "durations": []})
+            bucket["count"] += 1
+            bucket["durations"].append(dt)
+
+            messages.append({"role": "tool", "name": name, "content": tool_response})
+
+    return "<response>NOT_FOUND</response>  # exhausted max_iterations", tool_metrics
+
+
+REPORT_HEADER = """# Evaluation Report (Ollama)
+
+- **Model**: `{model}`
+- **Accuracy**: {correct}/{total} ({accuracy:.1f}%)
+- **Average task duration**: {avg_duration:.2f}s
+- **Average tool calls per task**: {avg_tool_calls:.2f}
+- **Total tool calls**: {total_tool_calls}
+
+---
+"""
+
+TASK_TEMPLATE = """
+### Task {n}
+
+**Question**: {question}
+**Expected**: `{expected}`
+**Actual**: `{actual}`
+**Correct**: {mark}
+**Duration**: {duration:.2f}s
+**Tool calls** ({num_tool_calls}): {tool_calls}
+
+**Summary**
+
+{summary}
+
+**Feedback**
+
+{feedback}
+
+---
+"""
+
+
+def format_report(model: str, results: list[dict[str, Any]]) -> str:
+    total = len(results)
+    correct = sum(r["score"] for r in results)
+    accuracy = (correct / total * 100) if total else 0.0
+    avg_duration = (sum(r["duration"] for r in results) / total) if total else 0.0
+    total_tool_calls = sum(r["num_tool_calls"] for r in results)
+    avg_tool_calls = (total_tool_calls / total) if total else 0.0
+
+    body = [
+        REPORT_HEADER.format(
+            model=model,
+            correct=correct,
+            total=total,
+            accuracy=accuracy,
+            avg_duration=avg_duration,
+            avg_tool_calls=avg_tool_calls,
+            total_tool_calls=total_tool_calls,
+        )
+    ]
+    for i, r in enumerate(results, start=1):
+        tool_summary = (
+            ", ".join(f"{name} x{m['count']}" for name, m in r["tool_metrics"].items()) or "-"
+        )
+        body.append(
+            TASK_TEMPLATE.format(
+                n=i,
+                question=r["question"],
+                expected=r["expected"],
+                actual=r["actual"] or "(no <response>)",
+                mark="✅" if r["score"] else "❌",
+                duration=r["duration"],
+                num_tool_calls=r["num_tool_calls"],
+                tool_calls=tool_summary,
+                summary=r["summary"] or "(no summary)",
+                feedback=r["feedback"] or "(no feedback)",
+            )
+        )
+    return "\n".join(body)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    eval_path = Path(args.eval).resolve()
+    if not eval_path.exists():
+        print(f"❌ Eval file not found: {eval_path}", file=sys.stderr)
+        return 2
+
+    qa_pairs = parse_evaluation_file(eval_path)
+    print(f"📋 Loaded {len(qa_pairs)} eval tasks from {eval_path}")
+
+    env: dict[str, str] = {}
+    for kv in args.env or []:
+        if "=" not in kv:
+            print(f"⚠️  Skipping malformed --env entry: {kv!r}", file=sys.stderr)
+            continue
+        k, v = kv.split("=", 1)
+        env[k] = v
+
+    ollama = OllamaAsyncClient(host=args.host)
+
+    server_args = shlex.split(args.args) if args.args else []
+    print(f"🚀 Launching MCP server: {args.command} {' '.join(server_args)}")
+    server_params = StdioServerParameters(command=args.command, args=server_args, env=env or None)
+
+    async with AsyncExitStack() as stack:
+        read, write = await stack.enter_async_context(stdio_client(server_params))
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+
+        tools_resp = await session.list_tools()
+        mcp_tools = [
+            {"name": t.name, "description": t.description, "input_schema": t.inputSchema}
+            for t in tools_resp.tools
+        ]
+        ollama_tools = mcp_tools_to_ollama(mcp_tools)
+        print(f"🔧 MCP server exposes {len(ollama_tools)} tools")
+
+        results: list[dict[str, Any]] = []
+        for i, qa in enumerate(qa_pairs, start=1):
+            print(f"\n[{i}/{len(qa_pairs)}] {qa['question'][:100]}...")
+            t0 = time.time()
+            try:
+                response_text, tool_metrics = await agent_loop(
+                    ollama, args.model, qa["question"], ollama_tools, session
+                )
+            except Exception as e:
+                print(f"  ⚠️  Task crashed: {e}")
+                response_text = ""
+                tool_metrics = {}
+            duration = time.time() - t0
+
+            actual = extract_response_with_fallback(response_text)
+            summary = extract_xml_content(response_text, "summary")
+            feedback = extract_xml_content(response_text, "feedback")
+            score = int(actual is not None and actual == qa["answer"])
+            num_tool_calls = sum(m["count"] for m in tool_metrics.values())
+
+            mark = "PASS" if score else "FAIL"
+            print(
+                f"  -> actual={actual!r}  expected={qa['answer']!r}  {mark}  "
+                f"({duration:.1f}s, {num_tool_calls} tool calls)"
+            )
+
+            results.append(
+                {
+                    "question": qa["question"],
+                    "expected": qa["answer"],
+                    "actual": actual,
+                    "score": score,
+                    "duration": duration,
+                    "tool_metrics": tool_metrics,
+                    "num_tool_calls": num_tool_calls,
+                    "summary": summary,
+                    "feedback": feedback,
+                }
+            )
+
+    report = format_report(args.model, results)
+    if args.output:
+        Path(args.output).write_text(report)
+        print(f"\n📝 Report written to {args.output}")
+    else:
+        print("\n" + report)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Run MCP eval against an Ollama-served model.")
+    p.add_argument("--eval", required=True, help="Path to evaluation XML file")
+    p.add_argument("--model", default="gpt-oss:120b-cloud", help="Ollama model to use")
+    p.add_argument("--host", default="http://localhost:11434", help="Ollama daemon URL")
+    p.add_argument("--output", "-o", help="Output path for the report (default: stdout)")
+    p.add_argument("-c", "--command", required=True, help="Command to launch MCP server (stdio)")
+    p.add_argument(
+        "-a",
+        "--args",
+        default="",
+        help="Args for the MCP server command, as a single shell-quoted string "
+        "(e.g. '-m comfyui_mcp.server'). Parsed with shlex.split.",
+    )
+    p.add_argument("-e", "--env", nargs="+", default=[], help="Env vars in KEY=VALUE form")
+    args = p.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/comfyui_mcp/workflow/validation.py
+++ b/src/comfyui_mcp/workflow/validation.py
@@ -66,7 +66,10 @@ def analyze_workflow(
 
         display_name = class_type
         if object_info and class_type in object_info:
-            display_name = object_info[class_type].get("display_name", class_type)
+            # Use the upstream display_name only if it's truthy — ComfyUI servers
+            # occasionally return ``{"display_name": None}`` or an empty string,
+            # which would otherwise propagate downstream and break string joins.
+            display_name = object_info[class_type].get("display_name") or class_type
 
         node_info[node_id] = {
             "node_id": node_id,

--- a/tests/test_tools_generation.py
+++ b/tests/test_tools_generation.py
@@ -318,6 +318,33 @@ class TestAnalyzeWorkflow:
         result = _analyze_workflow(workflow, object_info=object_info)
         assert result["flow"][0]["display_name"] == "Load Checkpoint"
 
+    def test_falls_back_when_display_name_is_explicit_none(self):
+        # Live ComfyUI servers occasionally return {"display_name": None}
+        # for nodes (observed on SaveAnimatedWEBP). The analyzer must
+        # fall back to class_type rather than propagate None, otherwise
+        # downstream ' -> '.join(flow_parts) crashes with
+        # "sequence item N: expected str instance, NoneType found".
+        workflow = {
+            "1": {
+                "class_type": "SaveAnimatedWEBP",
+                "inputs": {"filename_prefix": "anim"},
+            },
+        }
+        object_info = {"SaveAnimatedWEBP": {"display_name": None}}
+        result = _analyze_workflow(workflow, object_info=object_info)
+        assert result["flow"][0]["display_name"] == "SaveAnimatedWEBP"
+
+    def test_falls_back_when_display_name_is_empty_string(self):
+        workflow = {
+            "1": {
+                "class_type": "CustomNode",
+                "inputs": {},
+            },
+        }
+        object_info = {"CustomNode": {"display_name": ""}}
+        result = _analyze_workflow(workflow, object_info=object_info)
+        assert result["flow"][0]["display_name"] == "CustomNode"
+
     def test_handles_empty_workflow(self):
         result = _analyze_workflow({}, object_info=None)
         assert result["node_count"] == 0


### PR DESCRIPTION
## Summary

Adds a static-only Phase 4 evaluation suite for the MCP, following the `mcp-builder` skill's eval guidelines. The work also surfaced and fixes a real bug in the workflow summarizer.

### What's in here

- **`evals/2026-05-11-comfyui-mcp-v1.xml`** — 10 question/answer pairs targeting the MCP's static surface (built-in workflow templates, prompting guides, model presets, validator/summarizer/modifier behavior). Each question:
  - requires 2-5+ tool calls to answer,
  - has a single, verifiable, string-comparable answer,
  - depends only on data baked into the MCP (no live-ComfyUI state),
  - is realistic enough that a human + LLM might actually ask it.

- **Fix: `analyze_workflow` was propagating `None` from `object_info[class_type].get(\"display_name\", class_type)`.** The two-arg `.get()` default only fires when the key is absent — ComfyUI servers occasionally return `{\"display_name\": None}` (observed on `SaveAnimatedWEBP`), which bypassed the fallback. The `None` propagated into the flow list and the downstream `' -> '.join(flow_parts)` in `_format_summary` crashed with \`sequence item N: expected str instance, NoneType found\`.

  Concretely this broke `comfyui_summarize_workflow` for the `txt2vid_wan` and `txt2vid_animatediff` built-in templates (both include `SaveAnimatedWEBP`). Fix is one line: \`get(\"display_name\") or class_type\`. Two regression tests cover the \`None\` and empty-string cases.

  **The bug was found by drafting the eval** — exactly what Phase 4 is supposed to surface (\"evaluations test whether LLMs can effectively use your MCP server\").

## Test Plan

- [x] \`uv run pytest\` — 520 passed (+2 new regression tests over main's 518)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run mypy src/comfyui_mcp/\` — no issues
- [x] All 10 eval answers verified via direct \`mcp__comfyui__*\` tool calls or source inspection
- [x] After the fix: \`comfyui_summarize_workflow\` succeeds against \`txt2vid_animatediff\` and \`txt2vid_wan\` (previously crashed)
- [ ] Optional: run the eval script (\`mcp-builder\` skill's \`scripts/evaluation.py\` with \`ANTHROPIC_API_KEY\`) against the MCP to measure baseline accuracy

## Out of scope

- Eval questions covering live ComfyUI state (installed models, history, server features) — explicitly deferred since those answers aren't stable across server upgrades.
- Wiring the eval suite into CI as a regression gate — needs an Anthropic API key and budget decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)