### PR TITLE
Migrate progress tracker to /api/jobs/{id}

### DIFF
--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -181,11 +181,6 @@ class ComfyUIClient:
         r = await self._request("get", "/history", params=params or None)
         return r.json()
 
-    async def get_history_item(self, prompt_id: str) -> dict:
-        _validate_prompt_id(prompt_id)
-        r = await self._request("get", f"/history/{prompt_id}")
-        return r.json()
-
     async def get_job(self, job_id: str) -> dict:
         """GET /api/jobs/{job_id} — unified job lookup across queue + history."""
         _validate_prompt_id(job_id)

--- a/src/comfyui_mcp/progress.py
+++ b/src/comfyui_mcp/progress.py
@@ -255,6 +255,11 @@ class WebSocketProgress:
             collect_events=True,
         )
 
+    # ProgressState.status values that end the HTTP-polling fallback loop.
+    # Must mirror every terminal status _STATUS_MAP can produce — otherwise a
+    # job in a terminal state would keep polling until timeout.
+    _TERMINAL_STATUSES: ClassVar[frozenset[str]] = frozenset({"completed", "error", "interrupted"})
+
     async def _poll_until_complete(self, prompt_id: str, start_time: float) -> ProgressState:
         """Poll HTTP endpoints until completion or timeout."""
         interval = 1.0
@@ -265,7 +270,7 @@ class WebSocketProgress:
                 state.elapsed_seconds = round(elapsed, 2)
                 return state
             state = await self.get_state(prompt_id)
-            if state.status in ("completed", "error"):
+            if state.status in self._TERMINAL_STATUSES:
                 state.elapsed_seconds = round(time.monotonic() - start_time, 2)
                 return state
             await asyncio.sleep(interval)

--- a/src/comfyui_mcp/progress.py
+++ b/src/comfyui_mcp/progress.py
@@ -10,7 +10,7 @@ import ssl
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import urlparse
 
 import httpx
@@ -133,12 +133,28 @@ class WebSocketProgress:
 
         return False
 
-    def _state_from_history(self, entry: dict[str, Any], prompt_id: str) -> ProgressState:
-        """Build a completed ProgressState from a /history/{prompt_id} entry."""
-        state = ProgressState(prompt_id=prompt_id, status="completed")
-        outputs = entry.get("outputs", {})
-        for node_id, node_output in outputs.items():
-            state.outputs.extend(self._extract_outputs(node_id, node_output))
+    # Map ComfyUI's /api/jobs status enum to our internal ProgressState.status names.
+    # Upstream uses "in_progress" / "pending" / "completed" / "failed" / "cancelled".
+    _STATUS_MAP: ClassVar[dict[str, str]] = {
+        "completed": "completed",
+        "failed": "error",
+        "cancelled": "interrupted",
+        "in_progress": "running",
+        "pending": "queued",
+    }
+
+    def _state_from_job(self, job: dict[str, Any], prompt_id: str) -> ProgressState:
+        """Build a ProgressState from a /api/jobs/{id} response."""
+        upstream_status = job.get("status", "")
+        state = ProgressState(
+            prompt_id=prompt_id,
+            status=self._STATUS_MAP.get(upstream_status, "unknown"),
+        )
+        outputs = job.get("outputs") or {}
+        if isinstance(outputs, dict):
+            for node_id, node_output in outputs.items():
+                if isinstance(node_output, dict):
+                    state.outputs.extend(self._extract_outputs(node_id, node_output))
         return state
 
     async def _wait_internal(
@@ -165,12 +181,13 @@ class WebSocketProgress:
             async with asyncio.timeout(self._timeout):
                 async with websockets.connect(ws_url, **ws_kwargs) as ws:
                     # Pre-flight: if the job finished before this WS connection was
-                    # established, ComfyUI will not replay terminal events. Check
-                    # history immediately to avoid hanging until timeout.
+                    # established, ComfyUI will not replay terminal events. Hit the
+                    # unified /api/jobs/{id} endpoint immediately to avoid hanging
+                    # until timeout.
                     with contextlib.suppress(httpx.HTTPError, OSError):
-                        history = await self._client.get_history_item(prompt_id)
-                        if prompt_id in history:
-                            state = self._state_from_history(history[prompt_id], prompt_id)
+                        job = await self._client.get_job(prompt_id)
+                        if job and job.get("status") in {"completed", "failed", "cancelled"}:
+                            state = self._state_from_job(job, prompt_id)
                             if collect_events:
                                 events.append(
                                     {"type": "preflight_history", "data": {"prompt_id": prompt_id}}
@@ -255,32 +272,27 @@ class WebSocketProgress:
             interval = min(interval * 1.5, 10.0)
 
     async def get_state(self, prompt_id: str) -> ProgressState:
-        """Get current state via HTTP fallback (queue + history)."""
-        state = ProgressState(prompt_id=prompt_id)
+        """Get current state via the unified /api/jobs/{id} endpoint.
 
-        # Check history first (completed jobs)
+        For pending jobs we additionally consult /queue (best-effort) to derive
+        ``queue_position`` — the unified job response does not expose it.
+        """
+        job: dict[str, Any] | None = None
         with contextlib.suppress(httpx.HTTPError, OSError):
-            history = await self._client.get_history_item(prompt_id)
-            if prompt_id in history:
-                state.status = "completed"
-                entry = history[prompt_id]
-                outputs = entry.get("outputs", {})
-                for _node_id, node_output in outputs.items():
-                    state.outputs.extend(self._extract_outputs(_node_id, node_output))
-                return state
+            job = await self._client.get_job(prompt_id)
 
-        # Check queue (running/pending)
-        with contextlib.suppress(httpx.HTTPError, OSError):
-            queue = await self._client.get_queue()
-            for item in queue.get("queue_running", []):
-                if len(item) >= 2 and item[1] == prompt_id:
-                    state.status = "running"
-                    return state
-            pending = queue.get("queue_pending", [])
-            for i, item in enumerate(pending):
-                if len(item) >= 2 and item[1] == prompt_id:
-                    state.status = "queued"
-                    state.queue_position = i + 1
-                    return state
+        if job is None:
+            return ProgressState(prompt_id=prompt_id)
+
+        state = self._state_from_job(job, prompt_id)
+
+        if state.status == "queued":
+            with contextlib.suppress(httpx.HTTPError, OSError):
+                queue = await self._client.get_queue()
+                pending = queue.get("queue_pending", [])
+                for i, item in enumerate(pending):
+                    if len(item) >= 2 and item[1] == prompt_id:
+                        state.queue_position = i + 1
+                        break
 
         return state

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,19 +57,22 @@ class TestComfyUIClient:
 
     @respx.mock
     async def test_get_job_returns_job_object(self, client):
+        # Upstream ComfyUI returns the prompt id under the key "id" (see
+        # comfy_execution/jobs.py:normalize_history_item / normalize_queue_item).
+        # Fixtures across the suite mirror that contract.
         job_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         respx.get(f"http://test-comfyui:8188/api/jobs/{job_id}").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "prompt_id": job_id,
+                    "id": job_id,
                     "status": "in_progress",
                     "outputs": {},
                 },
             )
         )
         result = await client.get_job(job_id)
-        assert result["prompt_id"] == job_id
+        assert result["id"] == job_id
         assert result["status"] == "in_progress"
 
     async def test_get_job_rejects_non_uuid(self, client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -291,16 +291,6 @@ class TestComfyUIClient:
         await client.delete_queue_item("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
     @respx.mock
-    async def test_get_history_item(self, client):
-        respx.get("http://test-comfyui:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
-            return_value=httpx.Response(
-                200, json={"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {"outputs": {}}}
-            )
-        )
-        result = await client.get_history_item("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-        assert "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" in result
-
-    @respx.mock
     async def test_get_embeddings(self, client):
         respx.get("http://test-comfyui:8188/embeddings").mock(
             return_value=httpx.Response(200, json=["embedding1.pt", "embedding2.pt"])
@@ -610,18 +600,6 @@ class TestModelManagerClient:
 class TestPathInjectionValidation:
     """Verify that prompt_id and path segment validators block injection attempts."""
 
-    async def test_get_history_item_rejects_path_traversal(self, client):
-        with pytest.raises(ValueError, match="Invalid prompt_id"):
-            await client.get_history_item("../../../free")
-
-    async def test_get_history_item_rejects_empty(self, client):
-        with pytest.raises(ValueError, match="Invalid prompt_id"):
-            await client.get_history_item("")
-
-    async def test_get_history_item_rejects_non_uuid(self, client):
-        with pytest.raises(ValueError, match="Invalid prompt_id"):
-            await client.get_history_item("not-a-valid-uuid-format")
-
     async def test_delete_queue_item_rejects_path_traversal(self, client):
         with pytest.raises(ValueError, match="Invalid prompt_id"):
             await client.delete_queue_item("../../userdata")
@@ -649,10 +627,10 @@ class TestPathInjectionValidation:
     @respx.mock
     async def test_valid_uuid_passes_through(self, client):
         """Sanity check: valid UUID is accepted."""
-        respx.get("http://test-comfyui:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
-            return_value=httpx.Response(200, json={})
+        respx.get("http://test-comfyui:8188/api/jobs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
+            return_value=httpx.Response(200, json={"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"})
         )
-        result = await client.get_history_item("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        result = await client.get_job("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
         assert isinstance(result, dict)
 
     @respx.mock

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,7 +102,7 @@ class TestImageGenerationFlow:
             return_value=httpx.Response(
                 200,
                 json={
-                    "prompt_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
                     "status": "completed",
                     "outputs": {
                         "9": {
@@ -131,7 +131,7 @@ class TestImageGenerationFlow:
         job = await integration_stack["comfyui_get_job"](
             prompt_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         )
-        assert job["prompt_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert job["id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         assert job["status"] == "completed"
 
     @respx.mock

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -255,37 +255,25 @@ class TestWebSocketProgress:
 
         monkeypatch.setattr("comfyui_mcp.progress.websockets.connect", fail_connect)
 
-        # Simulate: first poll returns "running", second returns "completed"
+        # Simulate: first poll returns "in_progress", second returns "completed"
         prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        history_call_count = 0
+        job_call_count = 0
 
-        def history_side_effect(request):
-            nonlocal history_call_count
-            history_call_count += 1
-            if history_call_count >= 2:
+        def job_side_effect(request):
+            nonlocal job_call_count
+            job_call_count += 1
+            if job_call_count >= 2:
                 return httpx.Response(
                     200,
                     json={
-                        prompt_id: {
-                            "outputs": {
-                                "9": {"images": [{"filename": "out.png", "subfolder": ""}]}
-                            },
-                            "status": {"completed": True},
-                        }
+                        "id": prompt_id,
+                        "status": "completed",
+                        "outputs": {"9": {"images": [{"filename": "out.png", "subfolder": ""}]}},
                     },
                 )
-            return httpx.Response(200, json={})
+            return httpx.Response(200, json={"id": prompt_id, "status": "in_progress"})
 
-        respx.get(f"http://test:8188/history/{prompt_id}").mock(side_effect=history_side_effect)
-        respx.get("http://test:8188/queue").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "queue_running": [["0", prompt_id, {}, {}]],
-                    "queue_pending": [],
-                },
-            )
-        )
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(side_effect=job_side_effect)
 
         # Patch sleep to avoid real delays in tests
         monkeypatch.setattr("comfyui_mcp.progress.asyncio.sleep", AsyncMock())
@@ -298,31 +286,20 @@ class TestWebSocketProgress:
     async def test_get_state_http_fallback_completed(self):
         client = ComfyUIClient(base_url="http://test:8188")
         progress = WebSocketProgress(client, timeout=10.0)
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
-        respx.get("http://test:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {
-                        "outputs": {
-                            "9": {"images": [{"filename": "img.png", "subfolder": "output"}]}
-                        },
-                        "status": {"completed": True},
-                    }
-                },
-            )
-        )
-        respx.get("http://test:8188/queue").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "queue_running": [],
-                    "queue_pending": [],
+                    "id": prompt_id,
+                    "status": "completed",
+                    "outputs": {"9": {"images": [{"filename": "img.png", "subfolder": "output"}]}},
                 },
             )
         )
 
-        state = await progress.get_state("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        state = await progress.get_state(prompt_id)
         assert state.status == "completed"
         assert len(state.outputs) == 1
         assert state.outputs[0]["filename"] == "img.png"
@@ -331,10 +308,15 @@ class TestWebSocketProgress:
     async def test_get_state_http_fallback_queued(self):
         client = ComfyUIClient(base_url="http://test:8188")
         progress = WebSocketProgress(client, timeout=10.0)
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
-        respx.get("http://test:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
-            return_value=httpx.Response(200, json={})
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": prompt_id, "status": "pending"},
+            )
         )
+        # Queue is checked best-effort to derive a queue_position for pending jobs.
         respx.get("http://test:8188/queue").mock(
             return_value=httpx.Response(
                 200,
@@ -342,13 +324,13 @@ class TestWebSocketProgress:
                     "queue_running": [],
                     "queue_pending": [
                         [0, "other-id", {}, {}],
-                        [1, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", {}, {}],
+                        [1, prompt_id, {}, {}],
                     ],
                 },
             )
         )
 
-        state = await progress.get_state("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        state = await progress.get_state(prompt_id)
         assert state.status == "queued"
         assert state.queue_position == 2
 
@@ -356,22 +338,62 @@ class TestWebSocketProgress:
     async def test_get_state_http_fallback_running(self):
         client = ComfyUIClient(base_url="http://test:8188")
         progress = WebSocketProgress(client, timeout=10.0)
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
-        respx.get("http://test:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
-            return_value=httpx.Response(200, json={})
-        )
-        respx.get("http://test:8188/queue").mock(
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
             return_value=httpx.Response(
                 200,
-                json={
-                    "queue_running": [[0, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", {}, {}]],
-                    "queue_pending": [],
-                },
+                json={"id": prompt_id, "status": "in_progress"},
             )
         )
 
-        state = await progress.get_state("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        state = await progress.get_state(prompt_id)
         assert state.status == "running"
+
+    @respx.mock
+    async def test_get_state_maps_failed_to_error(self):
+        client = ComfyUIClient(base_url="http://test:8188")
+        progress = WebSocketProgress(client, timeout=10.0)
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": prompt_id, "status": "failed"},
+            )
+        )
+
+        state = await progress.get_state(prompt_id)
+        assert state.status == "error"
+
+    @respx.mock
+    async def test_get_state_maps_cancelled_to_interrupted(self):
+        client = ComfyUIClient(base_url="http://test:8188")
+        progress = WebSocketProgress(client, timeout=10.0)
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": prompt_id, "status": "cancelled"},
+            )
+        )
+
+        state = await progress.get_state(prompt_id)
+        assert state.status == "interrupted"
+
+    @respx.mock
+    async def test_get_state_returns_unknown_on_404(self):
+        client = ComfyUIClient(base_url="http://test:8188")
+        progress = WebSocketProgress(client, timeout=10.0)
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
+            return_value=httpx.Response(404, json={"error": "Job not found"})
+        )
+
+        state = await progress.get_state(prompt_id)
+        assert state.status == "unknown"
 
     @respx.mock
     async def test_preflight_history_check_avoids_hanging_on_fast_jobs(self, monkeypatch):
@@ -390,17 +412,14 @@ class TestWebSocketProgress:
 
         monkeypatch.setattr("comfyui_mcp.progress.websockets.connect", fake_connect)
 
-        # History endpoint immediately returns a completed entry
-        respx.get(f"http://test:8188/history/{prompt_id}").mock(
+        # /api/jobs/{id} immediately reports the job as completed
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    prompt_id: {
-                        "outputs": {
-                            "9": {"images": [{"filename": "fast.png", "subfolder": "output"}]}
-                        },
-                        "status": {"completed": True},
-                    }
+                    "id": prompt_id,
+                    "status": "completed",
+                    "outputs": {"9": {"images": [{"filename": "fast.png", "subfolder": "output"}]}},
                 },
             )
         )

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -283,6 +283,31 @@ class TestWebSocketProgress:
         assert state.elapsed_seconds is not None
 
     @respx.mock
+    async def test_ws_failure_polling_terminates_on_cancelled(self, monkeypatch):
+        """Regression: HTTP-polling fallback must treat 'interrupted' as terminal.
+
+        Before the fix, _poll_until_complete only broke on 'completed'/'error',
+        so a job that ended up cancelled would keep polling and return 'timeout'
+        instead of 'interrupted'.
+        """
+        client = ComfyUIClient(base_url="http://test:8188")
+        progress = WebSocketProgress(client, timeout=10.0)
+
+        def fail_connect(url, **kwargs):
+            raise OSError("Connection refused")
+
+        monkeypatch.setattr("comfyui_mcp.progress.websockets.connect", fail_connect)
+
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
+            return_value=httpx.Response(200, json={"id": prompt_id, "status": "cancelled"})
+        )
+        monkeypatch.setattr("comfyui_mcp.progress.asyncio.sleep", AsyncMock())
+
+        state = await progress.wait_for_completion(prompt_id)
+        assert state.status == "interrupted"
+
+    @respx.mock
     async def test_get_state_http_fallback_completed(self):
         client = ComfyUIClient(base_url="http://test:8188")
         progress = WebSocketProgress(client, timeout=10.0)

--- a/tests/test_tools_jobs.py
+++ b/tests/test_tools_jobs.py
@@ -187,25 +187,14 @@ class TestGetProgress:
     @respx.mock
     async def test_returns_completed_state(self, progress_components):
         client, audit, limiter, read_limiter, progress = progress_components
-        respx.get("http://test:8188/history/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").mock(
+        prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {
-                        "outputs": {
-                            "9": {"images": [{"filename": "out.png", "subfolder": "output"}]}
-                        },
-                        "status": {"completed": True},
-                    }
-                },
-            )
-        )
-        respx.get("http://test:8188/queue").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "queue_running": [],
-                    "queue_pending": [],
+                    "id": prompt_id,
+                    "status": "completed",
+                    "outputs": {"9": {"images": [{"filename": "out.png", "subfolder": "output"}]}},
                 },
             )
         )
@@ -218,28 +207,17 @@ class TestGetProgress:
             read_limiter=read_limiter,
             progress=progress,
         )
-        result = await tools["comfyui_get_progress"](
-            prompt_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        )
+        result = await tools["comfyui_get_progress"](prompt_id=prompt_id)
         assert result["status"] == "completed"
-        assert result["prompt_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert result["prompt_id"] == prompt_id
         assert len(result["outputs"]) == 1
 
     @respx.mock
     async def test_returns_unknown_when_not_found(self, progress_components):
         client, audit, limiter, read_limiter, progress = progress_components
         not_found_id = "11111111-2222-3333-4444-555555555555"
-        respx.get(f"http://test:8188/history/{not_found_id}").mock(
-            return_value=httpx.Response(200, json={})
-        )
-        respx.get("http://test:8188/queue").mock(
-            return_value=httpx.Response(
-                200,
-                json={
-                    "queue_running": [],
-                    "queue_pending": [],
-                },
-            )
+        respx.get(f"http://test:8188/api/jobs/{not_found_id}").mock(
+            return_value=httpx.Response(404, json={"error": "Job not found"})
         )
         mcp = FastMCP("test")
         tools = register_job_tools(

--- a/tests/test_tools_jobs.py
+++ b/tests/test_tools_jobs.py
@@ -91,13 +91,14 @@ class TestInterrupt:
 class TestGetJob:
     @respx.mock
     async def test_get_job_returns_unified_job_object(self, components):
+        # Upstream returns the prompt id as "id" — see comfy_execution/jobs.py.
         client, audit, limiter = components
         prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         respx.get(f"http://test:8188/api/jobs/{prompt_id}").mock(
             return_value=httpx.Response(
                 200,
                 json={
-                    "prompt_id": prompt_id,
+                    "id": prompt_id,
                     "status": "in_progress",
                     "outputs": {},
                 },
@@ -106,7 +107,7 @@ class TestGetJob:
         mcp = FastMCP("test")
         tools = register_job_tools(mcp, client, audit, limiter)
         result = await tools["comfyui_get_job"](prompt_id=prompt_id)
-        assert result["prompt_id"] == prompt_id
+        assert result["id"] == prompt_id
         assert result["status"] == "in_progress"
 
 
@@ -118,7 +119,7 @@ class TestListJobs:
             return_value=httpx.Response(
                 200,
                 json={
-                    "jobs": [{"prompt_id": "abc", "status": "completed"}],
+                    "jobs": [{"id": "abc", "status": "completed"}],
                     "pagination": {"offset": 0, "limit": None, "total": 1, "has_more": False},
                 },
             )


### PR DESCRIPTION
## Summary

Closes the maintenance hazard flagged in PR #69's final review: two tools (\`comfyui_get_job\` and \`comfyui_get_progress\`) were sourcing job data from different upstream endpoints, with risk of semantic drift. They now both go through ComfyUI's unified \`/api/jobs/{id}\`.

### Changes

- **\`progress.py\`** — both code paths that previously called \`/history/{prompt_id}\` now call \`client.get_job(prompt_id)\`:
  - Pre-flight check at WebSocket connect time (avoids hanging on jobs that finished before the WS attached)
  - HTTP-polling fallback path (used when WS connect fails)
- **Status mapping** introduced as a class-level constant:
  ```
  pending      -> queued
  in_progress  -> running
  completed    -> completed
  failed       -> error
  cancelled    -> interrupted   (new — was unreachable before)
  ```
- **\`queue_position\`** is still derived from \`/queue\` as a best-effort enrichment for pending jobs (the unified endpoint doesn't expose it). Job lookup remains correct even if the queue call fails.
- **\`ComfyUIClient.get_history_item\` removed** — no production callers after this migration. CLAUDE.md rule 8.

### Behavioral notes

- The new \`cancelled\` upstream status maps to \`interrupted\` — previously \`comfyui_get_progress\` couldn't distinguish a cancelled job from a failed one (both fell out of \`/history\` lookup). This is a small, additive improvement.
- Defensive coverage: \`_state_from_job\` handles missing/non-dict \`outputs\` gracefully (the unified endpoint omits \`outputs\` for non-terminal statuses).

## Test Plan

- [x] \`uv run pytest\` — 519 passed (+1 over main's 518)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run mypy src/comfyui_mcp/\` — no issues
- [x] New tests cover all five status mappings + the 404 branch
- [x] WebSocket pre-flight + HTTP-polling fallback both updated and tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)