### PR TITLE
Accept 'cancelled' as a valid /api/jobs status value

### DIFF
--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -16,7 +16,7 @@ _IDEMPOTENT_HTTP_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE"})
 _RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 _SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
-_VALID_JOB_STATUSES = frozenset({"pending", "in_progress", "completed", "failed"})
+_VALID_JOB_STATUSES = frozenset({"pending", "in_progress", "completed", "failed", "cancelled"})
 _VALID_JOB_SORT_BY = frozenset({"created_at", "execution_duration"})
 _VALID_JOB_SORT_ORDER = frozenset({"asc", "desc"})
 

--- a/src/comfyui_mcp/tools/jobs.py
+++ b/src/comfyui_mcp/tools/jobs.py
@@ -55,7 +55,7 @@ def register_job_tools(
         """Look up a single job by prompt_id across queue + history.
 
         Returns a flat unified job object with top-level keys: prompt_id, status
-        (pending/in_progress/completed/failed), timing fields (created_at,
+        (pending/in_progress/completed/failed/cancelled), timing fields (created_at,
         started_at, completed_at, execution_duration), outputs (when completed),
         and error (when failed). Use this to check on a job that may be queued,
         running, or already finished.
@@ -81,7 +81,7 @@ def register_job_tools(
     )
     async def comfyui_list_jobs(
         status: Annotated[
-            list[Literal["pending", "in_progress", "completed", "failed"]] | None,
+            list[Literal["pending", "in_progress", "completed", "failed", "cancelled"]] | None,
             Field(
                 default=None,
                 description="Filter by job status (any combination).",
@@ -111,7 +111,7 @@ def register_job_tools(
         """List jobs across queue and history with filtering, sorting, and pagination.
 
         Returns {"jobs": [...], "pagination": {"offset", "limit", "total", "has_more"}}.
-        Each job includes prompt_id, status (pending/in_progress/completed/failed),
+        Each job includes prompt_id, status (pending/in_progress/completed/failed/cancelled),
         timing, and outputs (when completed).
         """
         rl = read_limiter if read_limiter is not None else limiter

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -123,6 +123,39 @@ class TestComfyUIClient:
         with pytest.raises(ValueError, match="Invalid status"):
             await client.get_jobs(status=["bogus"])
 
+    @respx.mock
+    async def test_get_jobs_accepts_cancelled_status(self, client):
+        """ComfyUI's upstream JobStatus enum includes 'cancelled'; the client must too."""
+        route = respx.get("http://test-comfyui:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [],
+                    "pagination": {"offset": 0, "limit": None, "total": 0, "has_more": False},
+                },
+            )
+        )
+        await client.get_jobs(status=["cancelled"])
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["status"] == "cancelled"
+
+    @respx.mock
+    async def test_get_jobs_accepts_all_upstream_statuses(self, client):
+        """The client allowlist must stay in sync with ComfyUI's JobStatus.ALL."""
+        route = respx.get("http://test-comfyui:8188/api/jobs").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "jobs": [],
+                    "pagination": {"offset": 0, "limit": None, "total": 0, "has_more": False},
+                },
+            )
+        )
+        all_statuses = ["pending", "in_progress", "completed", "failed", "cancelled"]
+        await client.get_jobs(status=all_statuses)
+        params = dict(route.calls.last.request.url.params.multi_items())
+        assert params["status"] == ",".join(all_statuses)
+
     async def test_get_jobs_rejects_invalid_sort_by(self, client):
         with pytest.raises(ValueError, match="sort_by"):
             await client.get_jobs(sort_by="random")


### PR DESCRIPTION
## Summary

Closes a one-line drift between our client's status allowlist and ComfyUI's actual \`JobStatus.ALL\`:

| our \`_VALID_JOB_STATUSES\` (before) | upstream \`JobStatus.ALL\` |
|---|---|
| pending, in_progress, completed, failed | pending, in_progress, completed, failed, **cancelled** |

Effect of the bug: a caller of \`client.get_jobs(status=['cancelled'])\` (or the \`comfyui_list_jobs\` tool with that filter) hit our \`ValueError\` before the upstream request went out. Surfaced organically while reading \`comfy_execution/jobs.py\` for the PR #76 progress migration.

### Three sync points updated

- \`src/comfyui_mcp/client.py\` — \`_VALID_JOB_STATUSES\` adds \`\"cancelled\"\`.
- \`src/comfyui_mcp/tools/jobs.py\` — \`comfyui_list_jobs\`'s \`status\` param \`Literal\` adds \`\"cancelled\"\`. Docstrings on both \`comfyui_list_jobs\` and \`comfyui_get_job\` updated to advertise the full enum.

### Regression coverage

Two new tests in \`tests/test_client.py\`:

- \`test_get_jobs_accepts_cancelled_status\` — passes the single value through and asserts the wire \`status\` param.
- \`test_get_jobs_accepts_all_upstream_statuses\` — exhaustive check that all five \`JobStatus.ALL\` values are accepted in one call.

## Test Plan

- [x] \`uv run pytest\` — 522 passed (+2 over main's 520)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run mypy src/comfyui_mcp/\` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)