### PR TITLE
Rename preflight_history event marker to preflight_terminal

### DIFF
--- a/src/comfyui_mcp/progress.py
+++ b/src/comfyui_mcp/progress.py
@@ -190,7 +190,10 @@ class WebSocketProgress:
                             state = self._state_from_job(job, prompt_id)
                             if collect_events:
                                 events.append(
-                                    {"type": "preflight_history", "data": {"prompt_id": prompt_id}}
+                                    {
+                                        "type": "preflight_terminal",
+                                        "data": {"prompt_id": prompt_id},
+                                    }
                                 )
                             state.elapsed_seconds = round(time.monotonic() - start_time, 2)
                             return state, events

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -421,10 +421,10 @@ class TestWebSocketProgress:
         assert state.status == "unknown"
 
     @respx.mock
-    async def test_preflight_history_check_avoids_hanging_on_fast_jobs(self, monkeypatch):
+    async def test_preflight_terminal_check_avoids_hanging_on_fast_jobs(self, monkeypatch):
         """Jobs that complete before the WS connects must be caught by the pre-flight
-        history check so _wait_internal returns immediately instead of hanging until
-        the 300 s timeout (the race condition observed on the k3s cluster)."""
+        check against /api/jobs/{id} so _wait_internal returns immediately instead of
+        hanging until the 300 s timeout (the race condition observed on the k3s cluster)."""
         client = ComfyUIClient(base_url="http://test:8188")
         progress = WebSocketProgress(client, timeout=30.0)
         prompt_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -454,4 +454,4 @@ class TestWebSocketProgress:
         assert state.status == "completed"
         assert state.outputs[0]["filename"] == "fast.png"
         # Pre-flight path emits a marker event so callers know how it resolved
-        assert any(e["type"] == "preflight_history" for e in events)
+        assert any(e["type"] == "preflight_terminal" for e in events)


### PR DESCRIPTION
## Summary

Tiny cosmetic follow-up. The pre-flight check in \`progress.py\`'s WebSocket-wait path used to hit \`/history/{prompt_id}\`, but PR #76 migrated it to \`/api/jobs/{id}\`. The event marker it emits was still named \`preflight_history\`, which is now misleading.

Renamed to \`preflight_terminal\` — describes what was detected (the job was already in a terminal state before WebSocket attached) rather than the now-stale endpoint name. Matching test method and assertion updated.

## Test Plan

- [x] \`uv run pytest tests/test_progress.py\` — 19 passed
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/comfyui_mcp/\` — no issues

This is a low-level event-stream marker; consumers parsing the event stream from \`comfyui_run_workflow_stream\` need to update if they keyed on the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)