### PR TITLE
Tool description improvements (eval-driven)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | `comfyui_summarize_workflow` | Summarize a workflow's structure, data flow, models, and parameters. Supports `output_format="text"` (default) or `output_format="mermaid"` for diagram markup. |
 | `comfyui_create_workflow` | Create a workflow from templates including txt2img/img2img/upscale/inpaint, txt2vid_animatediff/txt2vid_wan, controlnet_canny/controlnet_depth/controlnet_openpose, ip_adapter, lora_stack, face_restore, flux_txt2img, and sdxl_txt2img. |
 | `comfyui_modify_workflow` | Apply batch operations (add_node, remove_node, set_input, connect, disconnect) to a workflow. |
+| `comfyui_analyze_workflow` | Return a structured analysis of a workflow as a dict (`node_count`, `class_types`, `flow`, `models`, `parameters`, `pipeline`, `prompt_nodes`, `negative_nodes`). Use this when you want to read fields like `pipeline` programmatically; use `comfyui_summarize_workflow` for a human-readable text or Mermaid rendering. |
 | `comfyui_validate_workflow` | Validate workflow structure, server compatibility, and security. |
 
 ### Job Management

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -509,8 +509,9 @@ def register_discovery_tools(
 
         The presets are static data baked into this MCP — they reflect
         community best-practice defaults, not anything the connected ComfyUI
-        server reports. Exactly one of ``model_name`` or ``model_family``
-        must be supplied; if both are given, ``model_family`` wins.
+        server reports. At least one of ``model_name`` or ``model_family``
+        must be supplied; if both are given, ``model_family`` takes
+        precedence and ``model_name`` is ignored.
 
         Args:
             model_name (required if ``model_family`` is omitted): Model

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -505,14 +505,31 @@ def register_discovery_tools(
         model_name: str | None = None,
         model_family: str | None = None,
     ) -> dict[str, Any]:
-        """Return recommended generation presets for a model family.
+        """Get recommended generation presets for a model family.
+
+        The presets are static data baked into this MCP — they reflect
+        community best-practice defaults, not anything the connected ComfyUI
+        server reports. Exactly one of ``model_name`` or ``model_family``
+        must be supplied; if both are given, ``model_family`` wins.
 
         Args:
-            model_name: Optional model filename to infer family from.
-            model_family: Optional explicit family (sd15, sdxl, flux, sd3, cascade).
+            model_name (required if ``model_family`` is omitted): Model
+                filename to auto-detect the family from (e.g.
+                ``sd_xl_base_1.0.safetensors`` → ``sdxl``). Used as a
+                fallback when ``model_family`` is empty.
+            model_family (required if ``model_name`` is omitted): Explicit
+                family identifier. Valid values: ``sd15``, ``sdxl``,
+                ``flux``, ``sd3``, ``cascade`` (aliases like ``sd1.5``,
+                ``stable-diffusion-xl``, ``flux.1``, ``sd3.5``,
+                ``stable-cascade`` are also accepted).
 
         Returns:
-            Dictionary containing normalized family and recommended settings.
+            Dict ``{"family": "<id>", "recommended": {<settings>}}`` where
+            ``recommended`` always contains the keys ``sampler`` (str),
+            ``scheduler`` (str), ``steps`` (int), ``cfg`` (float),
+            ``resolution`` (str like ``"1024x1024"``), ``clip_skip`` (int),
+            and ``notes`` (str). Callers that only need the settings can
+            read ``result["recommended"]`` directly.
         """
         limiter.check("get_model_presets")
         await audit.async_log(
@@ -551,10 +568,26 @@ def register_discovery_tools(
         )
     )
     async def comfyui_get_prompting_guide(model_family: str) -> dict[str, Any]:
-        """Return prompt-engineering guidance for a model family.
+        """Get the prompting guide for a model family.
+
+        The guide is static data baked into this MCP — it gives stylistic
+        and structural advice tuned to each family (prompt structure,
+        weighting syntax conventions, recommended quality tags, negative
+        prompt tips). It does not reflect the connected ComfyUI server's
+        installed models or state.
 
         Args:
-            model_family: Family name (sd15, sdxl, flux, sd3, cascade).
+            model_family (required): Family identifier. Valid values:
+                ``sd15``, ``sdxl``, ``flux``, ``sd3``, ``cascade`` (aliases
+                like ``sd1.5``, ``stable-diffusion-xl``, ``flux.1``,
+                ``sd3.5``, ``stable-cascade`` are also accepted).
+
+        Returns:
+            Dict ``{"family": "<id>", "guide": {<advice>}}`` where ``guide``
+            always contains the keys ``prompt_structure`` (str),
+            ``weight_syntax`` (str), ``quality_tags`` (list[str]), and
+            ``negative_prompt_tips`` (str). Callers that only need the
+            advice can read ``result["guide"]`` directly.
         """
         limiter.check("get_prompting_guide")
         normalized = _normalize_model_family(model_family)

--- a/src/comfyui_mcp/tools/workflow.py
+++ b/src/comfyui_mcp/tools/workflow.py
@@ -67,32 +67,45 @@ def register_workflow_tools(
             openWorldHint=False,
         )
     )
-    async def comfyui_create_workflow(template: str, params: str = "{}") -> dict[str, Any]:
+    async def comfyui_create_workflow(template: str, params: str = "") -> dict[str, Any]:
         """Create a ComfyUI workflow from a template with optional parameter overrides.
 
-        Available templates: txt2img, img2img, upscale, inpaint, txt2vid_animatediff,
-        txt2vid_wan, controlnet_canny, controlnet_depth, controlnet_openpose,
-        ip_adapter, lora_stack, face_restore, flux_txt2img, sdxl_txt2img.
+        Available templates: ``txt2img``, ``img2img``, ``upscale``, ``inpaint``,
+        ``txt2vid_animatediff``, ``txt2vid_wan``, ``controlnet_canny``,
+        ``controlnet_depth``, ``controlnet_openpose``, ``ip_adapter``,
+        ``lora_stack``, ``face_restore``, ``flux_txt2img``, ``sdxl_txt2img``.
 
         Args:
-            template: Template name (e.g. 'txt2img', 'img2img')
-            params: Optional JSON string of parameter overrides.
-                    Common params: prompt, negative_prompt, width, height,
-                    steps, cfg, model, denoise, controlnet_model,
-                    control_strength, lora_name, lora_strength.
+            template (required): Template name from the list above.
+            params (optional): JSON string of parameter overrides. Defaults to
+                an empty string, meaning "use template defaults". Pass either
+                ``""`` or ``"{}"`` for no overrides. Common keys:
+                ``prompt``, ``negative_prompt``, ``width``, ``height``,
+                ``steps``, ``cfg``, ``model``, ``denoise``, ``controlnet_model``,
+                ``control_strength``, ``lora_name``, ``lora_strength``.
+
+        Example:
+            ``comfyui_create_workflow(template="txt2img",
+            params='{"prompt": "a sunset", "width": 768, "steps": 30}')``
         """
         limiter.check("create_workflow")
         if len(params.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:
             raise ValueError(
                 f"Workflow JSON exceeds maximum size ({_MAX_WORKFLOW_JSON_BYTES} bytes)"
             )
-        try:
-            param_dict = json.loads(params)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON params: {e}") from e
 
-        if not isinstance(param_dict, dict):
-            raise ValueError('params must be a JSON object (e.g. {"key": "value"})')
+        # Empty string is the natural "no overrides" form. Treat it as {} so
+        # callers don't have to pass the literal '{}'.
+        if not params.strip():
+            param_dict: dict[str, Any] = {}
+        else:
+            try:
+                param_dict = json.loads(params)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON params: {e}") from e
+
+            if not isinstance(param_dict, dict):
+                raise ValueError('params must be a JSON object (e.g. {"key": "value"})')
 
         try:
             clean_params = _sanitize_template_params(param_dict, sanitizer)

--- a/src/comfyui_mcp/tools/workflow.py
+++ b/src/comfyui_mcp/tools/workflow.py
@@ -1,10 +1,12 @@
-"""Workflow composition tools: create_workflow, modify_workflow, validate_workflow."""
+"""Workflow composition tools: create, modify, validate, analyze."""
 
 from __future__ import annotations
 
+import contextlib
 import json
 from typing import Any
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -15,6 +17,7 @@ from comfyui_mcp.security.rate_limit import RateLimiter
 from comfyui_mcp.security.sanitizer import PathSanitizer, PathValidationError
 from comfyui_mcp.workflow.operations import apply_operations
 from comfyui_mcp.workflow.templates import create_from_template
+from comfyui_mcp.workflow.validation import analyze_workflow as _analyze_workflow
 from comfyui_mcp.workflow.validation import validate_workflow as _validate_workflow
 
 _MAX_WORKFLOW_JSON_BYTES = 10 * 1024 * 1024  # 10 MB
@@ -162,6 +165,78 @@ def register_workflow_tools(
         return result
 
     tool_fns["comfyui_modify_workflow"] = comfyui_modify_workflow
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        )
+    )
+    async def comfyui_analyze_workflow(workflow: str) -> dict[str, Any]:
+        """Analyze a ComfyUI workflow and return its structured shape.
+
+        Unlike ``comfyui_summarize_workflow`` (which formats a human-readable
+        text or Mermaid summary), this tool returns the raw analysis as a dict
+        so callers can read individual fields directly without parsing prose.
+
+        Args:
+            workflow (required): JSON string of the workflow to analyze. The
+                workflow JSON is a dict keyed by node ID; each value has
+                ``class_type`` and ``inputs``.
+
+        Returns:
+            Dict with keys:
+
+            - ``node_count`` (int): number of nodes in the workflow.
+            - ``class_types`` (list[str]): every ``class_type`` in topological
+              order.
+            - ``flow`` (list[dict]): per-node info — ``node_id``, ``class_type``,
+              ``display_name``, ``inputs`` — in topological order.
+            - ``models`` (list[dict]): single-field loader values, e.g.
+              ``[{"name": "v1-5-pruned.safetensors", "type": "checkpoints"}]``.
+            - ``parameters`` (dict): flat key/value of common sampler/latent
+              parameters extracted from the graph (``steps``, ``cfg``, ``width``,
+              ``height``, etc.).
+            - ``pipeline`` (str): coarse type — ``txt2img``, ``img2img``,
+              ``upscale``, ``img2img -> upscale``, or ``unknown``.
+            - ``prompt_nodes`` (list[str]): ids of ``CLIPTextEncode`` nodes
+              wired into the sampler's positive input.
+            - ``negative_nodes`` (list[str]): ids of ``CLIPTextEncode`` nodes
+              wired into the sampler's negative input.
+
+        Display-name enrichment is best-effort via ComfyUI's ``/object_info``
+        endpoint; if the server is unreachable, ``display_name`` falls back to
+        the bare ``class_type``.
+        """
+        limiter.check("analyze_workflow")
+        if len(workflow.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:
+            raise ValueError(
+                f"Workflow JSON exceeds maximum size ({_MAX_WORKFLOW_JSON_BYTES} bytes)"
+            )
+        try:
+            wf = json.loads(workflow)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON workflow: {e}") from e
+
+        if not isinstance(wf, dict):
+            raise ValueError("Workflow must be a JSON object keyed by node IDs")
+
+        # Best-effort enrichment from /object_info — analyzer handles None.
+        object_info: dict[str, Any] | None = None
+        with contextlib.suppress(httpx.HTTPError, OSError):
+            object_info = await client.get_object_info()
+
+        result = dict(_analyze_workflow(wf, object_info))
+        await audit.async_log(
+            tool="analyze_workflow",
+            action="analyzed",
+            extra={"node_count": result["node_count"], "pipeline": result["pipeline"]},
+        )
+        return result
+
+    tool_fns["comfyui_analyze_workflow"] = comfyui_analyze_workflow
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/src/comfyui_mcp/tools/workflow.py
+++ b/src/comfyui_mcp/tools/workflow.py
@@ -133,16 +133,34 @@ def register_workflow_tools(
     async def comfyui_modify_workflow(workflow: str, operations: str) -> dict[str, Any]:
         """Apply batch operations to a ComfyUI workflow.
 
-        Operations: add_node, remove_node, set_input, connect, disconnect.
-        Operations execute sequentially. If any fails, the workflow is unchanged.
+        Operations execute sequentially in array order. If any operation fails,
+        the workflow is returned unchanged (transactional).
 
         Args:
-            workflow: JSON string of the workflow to modify.
-            operations: JSON string of an array of operation objects.
-                        Each has an 'op' field and operation-specific fields.
-                        Example: [{"op": "add_node", "class_type": "LoraLoader"},
-                                  {"op": "connect", "from_node": "1", "from_output": 0,
-                                   "to_node": "3", "to_input": "model"}]
+            workflow (required): JSON string of the workflow to modify.
+            operations (required): JSON string of an array of operation objects.
+
+        Operation reference:
+
+        - ``add_node`` — append a new node. Fields:
+          ``{"op": "add_node", "class_type": "<NodeType>",
+             "node_id": "<id>" (optional, auto-assigned if omitted),
+             "inputs": {...} (optional default inputs)}``
+        - ``remove_node`` — drop a node. Fields:
+          ``{"op": "remove_node", "node_id": "<id>"}``
+        - ``set_input`` — set or replace a single input value. Fields:
+          ``{"op": "set_input", "node_id": "<id>",
+             "input_name": "<key>", "value": <any>}``
+        - ``connect`` — wire one node's output into another's input. Fields:
+          ``{"op": "connect", "from_node": "<id>", "from_output": <int>,
+             "to_node": "<id>", "to_input": "<key>"}``
+        - ``disconnect`` — clear an existing input connection. Fields:
+          ``{"op": "disconnect", "node_id": "<id>", "input_name": "<key>"}``
+
+        Example:
+            ``operations='[{"op": "set_input", "node_id": "3",
+            "input_name": "steps", "value": 50},
+            {"op": "add_node", "class_type": "LoraLoader"}]'``
         """
         limiter.check("modify_workflow")
         if len(workflow.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:
@@ -266,11 +284,24 @@ def register_workflow_tools(
         available models, dangerous nodes, and suspicious inputs.
 
         Args:
-            workflow: JSON string of the workflow to validate.
+            workflow (required): JSON string of the workflow to validate.
 
         Returns:
-            Dict with keys: valid (bool), errors (list), warnings (list),
-            node_count (int), pipeline (str).
+            Dict with keys:
+
+            - ``valid`` (bool): True only if there are zero entries in ``errors``.
+            - ``errors`` (list[str]): blocking issues — invalid structure,
+              connections that reference nonexistent nodes, missing required
+              inputs, etc. Each entry is a human-readable string identifying
+              the offending node id and what's wrong.
+            - ``warnings`` (list[str]): non-blocking concerns — unknown
+              ``class_type`` not advertised by the connected server,
+              missing model files, dangerous node names, suspicious input
+              patterns (e.g. ``__import__``).
+            - ``node_count`` (int): number of nodes in the workflow.
+            - ``pipeline`` (str): coarse type — ``txt2img``, ``img2img``,
+              ``upscale``, ``img2img -> upscale``, or ``unknown``. (For the
+              full structural breakdown, use ``comfyui_analyze_workflow``.)
         """
         limiter.check("validate_workflow")
         if len(workflow.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:

--- a/src/comfyui_mcp/tools/workflow.py
+++ b/src/comfyui_mcp/tools/workflow.py
@@ -90,9 +90,7 @@ def register_workflow_tools(
         """
         limiter.check("create_workflow")
         if len(params.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:
-            raise ValueError(
-                f"Workflow JSON exceeds maximum size ({_MAX_WORKFLOW_JSON_BYTES} bytes)"
-            )
+            raise ValueError(f"params JSON exceeds maximum size ({_MAX_WORKFLOW_JSON_BYTES} bytes)")
 
         # Empty string is the natural "no overrides" form. Treat it as {} so
         # callers don't have to pass the literal '{}'.
@@ -134,7 +132,8 @@ def register_workflow_tools(
         """Apply batch operations to a ComfyUI workflow.
 
         Operations execute sequentially in array order. If any operation fails,
-        the workflow is returned unchanged (transactional).
+        the call raises ``ValueError`` and the input workflow is left
+        unmodified (atomic — operations are applied to a deep copy).
 
         Args:
             workflow (required): JSON string of the workflow to modify.
@@ -177,7 +176,7 @@ def register_workflow_tools(
 
         if len(operations.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:
             raise ValueError(
-                f"Workflow JSON exceeds maximum size ({_MAX_WORKFLOW_JSON_BYTES} bytes)"
+                f"operations JSON exceeds maximum size ({_MAX_WORKFLOW_JSON_BYTES} bytes)"
             )
         try:
             ops = json.loads(operations)
@@ -230,12 +229,16 @@ def register_workflow_tools(
             - ``parameters`` (dict): flat key/value of common sampler/latent
               parameters extracted from the graph (``steps``, ``cfg``, ``width``,
               ``height``, etc.).
-            - ``pipeline`` (str): coarse type — ``txt2img``, ``img2img``,
-              ``upscale``, ``img2img -> upscale``, or ``unknown``.
+            - ``pipeline`` (str): coarse type — one of ``txt2img``,
+              ``img2img``, ``upscale``, ``img2img -> upscale``,
+              ``txt2img -> upscale``, or ``unknown``.
             - ``prompt_nodes`` (list[str]): ids of ``CLIPTextEncode`` nodes
-              wired into the sampler's positive input.
+              that are NOT wired into any sampler's ``negative`` input
+              (the analyzer treats every non-negative CLIPTextEncode as
+              a positive prompt — it does not separately verify that it
+              is wired into a sampler's positive input).
             - ``negative_nodes`` (list[str]): ids of ``CLIPTextEncode`` nodes
-              wired into the sampler's negative input.
+              wired into a sampler's ``negative`` input.
 
         Display-name enrichment is best-effort via ComfyUI's ``/object_info``
         endpoint; if the server is unreachable, ``display_name`` falls back to
@@ -291,17 +294,19 @@ def register_workflow_tools(
 
             - ``valid`` (bool): True only if there are zero entries in ``errors``.
             - ``errors`` (list[str]): blocking issues — invalid structure,
-              connections that reference nonexistent nodes, missing required
-              inputs, etc. Each entry is a human-readable string identifying
-              the offending node id and what's wrong.
-            - ``warnings`` (list[str]): non-blocking concerns — unknown
-              ``class_type`` not advertised by the connected server,
-              missing model files, dangerous node names, suspicious input
-              patterns (e.g. ``__import__``).
+              connections that reference nonexistent nodes, ``class_type``
+              not installed on the connected server, missing required
+              inputs, security blocks, etc. Each entry is a human-readable
+              string identifying the offending node id and what's wrong.
+            - ``warnings`` (list[str]): non-blocking concerns — missing model
+              files, dangerous node names, suspicious input patterns
+              (e.g. ``__import__``), or a server-unreachable note when the
+              installed-class_type check has to be skipped.
             - ``node_count`` (int): number of nodes in the workflow.
-            - ``pipeline`` (str): coarse type — ``txt2img``, ``img2img``,
-              ``upscale``, ``img2img -> upscale``, or ``unknown``. (For the
-              full structural breakdown, use ``comfyui_analyze_workflow``.)
+            - ``pipeline`` (str): coarse type — one of ``txt2img``,
+              ``img2img``, ``upscale``, ``img2img -> upscale``,
+              ``txt2img -> upscale``, or ``unknown``. (For the full
+              structural breakdown, use ``comfyui_analyze_workflow``.)
         """
         limiter.check("validate_workflow")
         if len(workflow.encode("utf-8")) > _MAX_WORKFLOW_JSON_BYTES:

--- a/tests/test_tools_workflow.py
+++ b/tests/test_tools_workflow.py
@@ -258,3 +258,44 @@ class TestAnalyzeWorkflow:
         result = await tools["comfyui_analyze_workflow"](workflow=json.dumps(workflow))
         assert result["pipeline"] == "txt2img"
         assert result["node_count"] == 3
+
+
+class TestCreateWorkflowParamsDefault:
+    """The params parameter should accept an empty string as 'no overrides',
+    not just the literal '{}'. Real eval data showed agents tripped on this."""
+
+    @respx.mock
+    async def test_empty_string_means_no_overrides(self, components):
+        client, audit, limiter, inspector, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        result = await tools["comfyui_create_workflow"](template="txt2img", params="")
+        assert isinstance(result, dict)
+        class_types = {n["class_type"] for n in result.values() if isinstance(n, dict)}
+        assert "KSampler" in class_types
+
+    @respx.mock
+    async def test_empty_object_string_still_works(self, components):
+        """Back-compat: '{}' still means no overrides too."""
+        client, audit, limiter, inspector, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        result = await tools["comfyui_create_workflow"](template="txt2img", params="{}")
+        assert isinstance(result, dict)
+
+    @respx.mock
+    async def test_omitting_params_works(self, components):
+        """Calling without the params kwarg uses the default of no overrides."""
+        client, audit, limiter, inspector, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        result = await tools["comfyui_create_workflow"](template="txt2img")
+        assert isinstance(result, dict)
+
+    async def test_invalid_json_still_rejected(self, components):
+        """Non-empty, non-JSON inputs still raise."""
+        client, audit, limiter, inspector, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        with pytest.raises(ValueError, match="Invalid JSON params"):
+            await tools["comfyui_create_workflow"](template="txt2img", params="not json")

--- a/tests/test_tools_workflow.py
+++ b/tests/test_tools_workflow.py
@@ -186,3 +186,75 @@ class TestIntegration:
         # Validate
         validated = await tools["comfyui_validate_workflow"](workflow=json.dumps(modified))
         assert validated["node_count"] == len(modified)
+
+
+class TestAnalyzeWorkflow:
+    @respx.mock
+    async def test_returns_structured_analysis(self, components):
+        client, audit, limiter, inspector, sanitizer = components
+        respx.get("http://test:8188/object_info").mock(return_value=httpx.Response(200, json={}))
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        workflow = {
+            "1": {"class_type": "EmptyLatentImage", "inputs": {"width": 768, "height": 512}},
+            "2": {"class_type": "KSampler", "inputs": {"steps": 30, "latent_image": ["1", 0]}},
+            "3": {"class_type": "SaveImage", "inputs": {"images": ["2", 0]}},
+        }
+        result = await tools["comfyui_analyze_workflow"](workflow=json.dumps(workflow))
+        assert result["node_count"] == 3
+        assert result["pipeline"] == "txt2img"
+        assert result["parameters"]["width"] == 768
+        assert result["parameters"]["height"] == 512
+        assert result["parameters"]["steps"] == 30
+        assert "EmptyLatentImage" in result["class_types"]
+        assert "KSampler" in result["class_types"]
+
+    @respx.mock
+    async def test_pipeline_field_directly_readable(self, components):
+        """Regression: qwen3-coder's eval failure on Q3 was caused by parsing the
+        Pipeline: line from comfyui_summarize_workflow's text output and only
+        catching the first segment ('img2img'). The new tool exposes pipeline
+        as a structured field so this failure mode is gone."""
+        client, audit, limiter, inspector, sanitizer = components
+        respx.get("http://test:8188/object_info").mock(return_value=httpx.Response(200, json={}))
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        workflow = {
+            "1": {"class_type": "LoadImage", "inputs": {"image": "in.png"}},
+            "2": {"class_type": "ImageUpscaleWithModel", "inputs": {"image": ["1", 0]}},
+        }
+        result = await tools["comfyui_analyze_workflow"](workflow=json.dumps(workflow))
+        assert result["pipeline"] == "img2img -> upscale"
+
+    async def test_rejects_invalid_json(self, components):
+        client, audit, limiter, inspector, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        with pytest.raises(ValueError, match="Invalid JSON workflow"):
+            await tools["comfyui_analyze_workflow"](workflow="not json")
+
+    async def test_rejects_non_dict(self, components):
+        client, audit, limiter, inspector, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            await tools["comfyui_analyze_workflow"](workflow="[1, 2, 3]")
+
+    @respx.mock
+    async def test_falls_back_when_object_info_unreachable(self, components):
+        """If the server is down or returns an error, analysis still works for
+        the structural fields (just without display_name enrichment)."""
+        client, audit, limiter, inspector, sanitizer = components
+        respx.get("http://test:8188/object_info").mock(
+            return_value=httpx.Response(500, json={"error": "boom"})
+        )
+        mcp = FastMCP("test")
+        tools = register_workflow_tools(mcp, client, audit, limiter, inspector, sanitizer)
+        workflow = {
+            "1": {"class_type": "EmptyLatentImage", "inputs": {"width": 512, "height": 512}},
+            "2": {"class_type": "KSampler", "inputs": {"latent_image": ["1", 0]}},
+            "3": {"class_type": "SaveImage", "inputs": {"images": ["2", 0]}},
+        }
+        result = await tools["comfyui_analyze_workflow"](workflow=json.dumps(workflow))
+        assert result["pipeline"] == "txt2img"
+        assert result["node_count"] == 3


### PR DESCRIPTION
## Summary

Acts on concrete signal from running the Phase 4 eval against `gpt-oss:120b-cloud` and `qwen3-coder:480b-cloud`. Agents repeatedly flagged the same friction points:

- The `pipeline` field could only be read by parsing `comfyui_summarize_workflow`'s prose output — qwen3-coder's one tool-attributable Q3 failure was caused by catching only the first segment of `"Pipeline: img2img -> upscale"`.
- `comfyui_create_workflow`'s `params: str = "{}"` default forced callers to pass the literal string `"{}"` for no overrides; passing `""` blew up.
- `comfyui_modify_workflow`'s per-operation field names (`input_name`, `from_node`, etc.) weren't documented inline — agents trial-and-errored their way through.
- `comfyui_validate_workflow`'s docstring listed result keys but said nothing about the *contents* of `errors`/`warnings`.
- `comfyui_get_model_presets` / `comfyui_get_prompting_guide` lacked required/optional markers and named return-field guarantees.

### Changes

- **New `comfyui_analyze_workflow` tool** — exposes the existing `analyze_workflow()` helper as a structured-dict MCP tool. Returns `node_count`, `class_types`, `flow`, `models`, `parameters`, `pipeline`, `prompt_nodes`, `negative_nodes` directly so callers can read individual fields without parsing prose. Eliminates the qwen3 Q3 failure mode.
- **`comfyui_create_workflow` accepts empty `params`** — default changed from `"{}"` to `""`; empty/whitespace-only treated as "no overrides". `"{}"` still works. Docstring includes a worked example.
- **`comfyui_modify_workflow` docstring** — enumerates every op (`add_node`, `remove_node`, `set_input`, `connect`, `disconnect`) with its exact JSON shape. Caught that `disconnect` uses `node_id`/`input_name` (asymmetric with `connect`'s `to_node`/`to_input`) and documented that as it is.
- **`comfyui_validate_workflow` docstring** — spells out per-key return shape: `valid` is `len(errors) == 0`; `errors` and `warnings` are `list[str]` of human-readable f-strings.
- **`comfyui_get_model_presets` / `comfyui_get_prompting_guide` docstrings** — required/optional markers, actual return shapes (the original plan's draft was wrong on both — `get_prompting_guide` has no `model_name` param and returns nested `{"family", "guide": {...}}` not flat), notes that the data is static.
- **README** — Tools-table row for the new `comfyui_analyze_workflow`.

## Test plan

- [x] Full suite: 540/540 passing (+9 over main: 5 analyze tests + 4 create-params tests)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/comfyui_mcp/` clean
- [x] `pre-commit run --files <changed>` clean
- [x] Exactly one new `@mcp.tool` registered: `comfyui_analyze_workflow`
- [ ] Smoke-test against a live ComfyUI server (optional — no client/wire changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)