### PR TITLE
Multi-model eval wrapper to work around CLI single-model limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,14 @@ uv run inspect eval evals/comfyui_mcp_task.py@comfyui_mcp_phase5 \
     --log-dir ./logs/phase5
 
 # Run the eval across multiple models in one shot
-uv run inspect eval-set evals/comfyui_mcp_task.py \
-    --model ollama/gpt-oss:120b-cloud \
-    --model ollama/qwen3-coder:480b-cloud \
-    --model anthropic/claude-sonnet-4-6 \
+# (inspect's --model flag is single-value; the wrapper calls eval_set()
+# directly with model=[...] to work around that)
+uv run python scripts/run_multimodel_eval.py evals/comfyui_mcp_task.py@comfyui_mcp_phase4 \
+    --models ollama/gpt-oss:120b-cloud,ollama/qwen3-coder:480b-cloud,anthropic/claude-sonnet-4-6 \
     --log-dir ./logs/phase4-cross-model
+
+# Compare two eval runs (or two .eval files) side-by-side
+uv run python scripts/compare_evals.py logs/phase4 logs/phase4-cross-model
 ```
 
 ## Rules

--- a/scripts/run_multimodel_eval.py
+++ b/scripts/run_multimodel_eval.py
@@ -1,0 +1,65 @@
+"""Run a single Inspect AI Task against multiple models in one invocation.
+
+The CLI's ``--model`` flag is single-value (Click's default), so
+``inspect eval-set --model A --model B`` silently drops the first one. This
+wrapper bridges that gap by calling the ``eval_set()`` Python API directly,
+which DOES accept a list of model IDs.
+
+Usage:
+
+    uv run python scripts/run_multimodel_eval.py \\
+        evals/comfyui_mcp_task.py@comfyui_mcp_phase4 \\
+        --models ollama/gpt-oss:120b-cloud,ollama/qwen3-coder:480b-cloud \\
+        --log-dir ./logs/phase4-multimodel
+
+The wrapper passes through ``COMFYUI_URL`` (and any other env vars) to the
+MCP server subprocess via the Task definition's own ``os.environ.get(...)``
+default, so set them before invoking this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from inspect_ai import eval_set
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run an Inspect AI Task against multiple models in one invocation.",
+    )
+    parser.add_argument(
+        "task",
+        help="Task reference, e.g. 'evals/comfyui_mcp_task.py@comfyui_mcp_phase4'",
+    )
+    parser.add_argument(
+        "--models",
+        required=True,
+        help=(
+            "Comma-separated list of model IDs, e.g. "
+            "'ollama/gpt-oss:120b-cloud,ollama/qwen3-coder:480b-cloud'"
+        ),
+    )
+    parser.add_argument(
+        "--log-dir",
+        required=True,
+        help="Directory to write .eval logs to. Must be empty or hold a matching eval-set.",
+    )
+    args = parser.parse_args()
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    if not models:
+        print("error: --models requires at least one model", file=sys.stderr)
+        return 2
+
+    success, _logs = eval_set(
+        tasks=[args.task],
+        model=models,
+        log_dir=args.log_dir,
+    )
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The `inspect eval-set --model A --model B` example that's been in CLAUDE.md since the Inspect AI port doesn't actually work — `--model` is single-value by Click's default, so the first one is silently dropped. Confirmed by reading `_cli/eval.py`: line 98-102 declares `--model` without `multiple=True`.

The Python `eval_set()` API accepts `model: list[str] | str`, so the fix is a thin wrapper that calls it directly.

## Files

- New: `scripts/run_multimodel_eval.py` (~50 lines) — CLI wrapper that accepts comma-separated `--models` and calls `eval_set(model=[...])`
- Modified: `CLAUDE.md` — replaces the broken `inspect eval-set --model A --model B` example with the wrapper invocation; adds a `compare_evals` follow-up line

## Usage

```bash
uv run python scripts/run_multimodel_eval.py \
    evals/comfyui_mcp_task.py@comfyui_mcp_phase4 \
    --models ollama/gpt-oss:120b-cloud,ollama/qwen3-coder:480b-cloud \
    --log-dir ./logs/phase4-cross-model
```

## Verified

Tested with `mockllm/A,mockllm/B` (since Ollama Cloud was flaky):
- `eval-set.json` registers two task entries (one per model)
- Two `.eval` files written to the log dir
- `inspect view --log-dir <dir>` shows both grouped

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy` clean
- [x] Smoke-tested with two distinct mock models
- [x] `pytest` not affected (no production code touched)
- [ ] CI (down through 2026-06-01) — verified locally; admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)