### PR TITLE
Expand .graphifyignore with operational + report directories

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -3,3 +3,21 @@
 
 # Internal planning artifacts — not part of the public repo's domain content.
 docs/superpowers/
+
+# Historical eval reports — point-in-time per-model run snapshots, not domain
+# knowledge. The eval datasets (evals/*.jsonl) and the Task module
+# (evals/comfyui_mcp_task.py) ARE indexed; only the per-run reports are excluded.
+evals/*-report-*.md
+
+# Eval run outputs (.eval logs, intermediate files, large).
+logs/
+
+# Build artifacts.
+dist/
+
+# Project-internal automation and agent/runtime config — operational, not domain.
+hooks/
+.github/
+.claude/
+.claude-plugin/
+.worktrees/


### PR DESCRIPTION
## Summary

After reviewing what graphify currently picks up, three categories of files create noise without adding domain signal:

1. **Historical eval reports** (`evals/2026-05-11-report-*.md`) — point-in-time per-model run snapshots. They re-mention every MCP tool name and create false-attributed concept nodes. The eval datasets and Task module stay indexed.
2. **Eval run outputs** (`logs/`) — large `.eval` binary-ish logs.
3. **Build/operational/agent config** (`dist/`, `hooks/`, `.github/`, `.claude/`, `.claude-plugin/`, `.worktrees/`) — not domain content.

## Verified

Used `graphify.detect._is_ignored` against representative paths:

| Path | Result |
|---|---|
| `evals/2026-05-11-report-gpt-oss-120b.md` | IGNORE ✓ |
| `evals/2026-05-11-comfyui-mcp-v1.jsonl` | KEEP ✓ |
| `evals/comfyui_mcp_task.py` | KEEP ✓ |
| `logs/phase4-smoke/foo.eval` | IGNORE ✓ |
| `dist/whatever.whl` | IGNORE ✓ |
| `.github/workflows/ci.yml` | IGNORE ✓ |
| `src/comfyui_mcp/client.py` | KEEP ✓ |

## Test plan

- [x] Pattern verification against `_is_ignored` (see table above)
- [x] No production code touched
- [ ] CI (down through 2026-06-01) — admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)