### PR TITLE
CLAUDE.md refresh + skill v2 drift + plugin version bump

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "comfy",
   "description": "ComfyUI image generation via MCP with slash commands and skills",
-  "version": "1.0.0"
+  "version": "2.1.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,14 @@ A secure MCP (Model Context Protocol) server for ComfyUI. Enables AI assistants 
 - Audit Logger (structured JSON logging)
 - Selective API surface (blocks dangerous endpoints)
 
+## Operational Status
+
+> **CI is down until 2026-06-01** (billing issue, not project-related). Until then:
+> - Verify the full local suite before merging: `uv run pytest -q && uv run ruff check src/ tests/ evals/ scripts/ && uv run ruff format --check src/ tests/ evals/ scripts/ && uv run mypy src/comfyui_mcp/`.
+> - Use `gh pr merge <N> --squash --admin --delete-branch` to bypass status-check gating.
+> - The PyPI publish workflow (`.github/workflows/pypi.yml`) is unaffected and still runs on tag push.
+> - Remove this banner after 2026-06-01.
+
 ## Tech Stack
 
 - **Python**: 3.12
@@ -135,6 +143,30 @@ These are non-negotiable. This is a security-focused project.
 16. **No `@pytest.mark.asyncio` decorators.** `asyncio_mode = auto` is set in `pyproject.toml`. The markers are redundant noise.
 17. **No duplicate test method names.** Python silently shadows the first definition. Each test method in a class must have a unique name.
 18. **Mock ComfyUI responses with `respx`.** Use `@respx.mock` decorator and `respx.get/post().mock()` to simulate ComfyUI API responses. Never make real HTTP calls in tests.
+
+### Eval workflow rules
+
+22. **Run the Phase 4 eval before merging anything that changes tool descriptions, parameter schemas, or return shapes.** The eval is the regression signal for LLM-facing tool surface changes. Single-model run takes 1-6 min depending on model.
+    ```bash
+    uv run inspect eval evals/comfyui_mcp_task.py@comfyui_mcp_phase4 --model ollama/qwen3-coder:480b-cloud --log-dir ./logs/phase4-pre-merge
+    ```
+23. **Compare eval runs with `scripts/compare_evals.py`.** When the same eval is run before and after a change, diff them. The script shows per-sample PASS/FAIL plus a per-tag breakdown so you can answer "which tag of questions regressed?".
+    ```bash
+    uv run python scripts/compare_evals.py logs/phase4-before logs/phase4-after
+    ```
+24. **Tag new eval questions.** Every JSONL sample must have a `tags` field listing what it tests (e.g. `["template", "recovery"]`). See existing entries for the canonical tag taxonomy. The task module's `FieldSpec(... metadata=["tags"])` carries them through into the `.eval` log.
+25. **Don't commit `.eval` logs.** `logs/` is gitignored and `.graphifyignore`'d. Generated images on the ComfyUI server from Phase 5 runs accumulate — clean those manually if needed.
+
+### Release & PR workflow
+
+26. **Squash-merge convention.** Every PR is squash-merged with title in the form `Imperative summary (#N)` (gh's default). Squash-merge produces one commit per PR on `main`; never use merge commits or rebase-merges.
+27. **Conventional commit body.** Commit message body explains *why*. End every commit with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` (or the active model identifier) when authored with Claude.
+28. **CHANGELOG-driven releases.** Cutting a release requires three coordinated edits:
+    1. Bump `pyproject.toml` `[project].version`
+    2. Promote `CHANGELOG.md`'s `[Unreleased]` section to `[X.Y.Z] — YYYY-MM-DD` with a summary paragraph and `### Added` / `### Changed` / `### Fixed` / `### Removed` sub-sections
+    3. Add the `[X.Y.Z]: https://github.com/hybridindie/comfyui_mcp/releases/tag/vX.Y.Z` link reference at the bottom
+29. **Tag → PyPI → GitHub Release.** The PyPI workflow auto-publishes on `git push origin vX.Y.Z`, but the GitHub Release is NOT auto-created — run `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."` manually after the PyPI publish succeeds (we hit this gotcha for 2.0.0 and 2.1.0).
+30. **No force-push to `main`.** Even during the CI-down window, never force-push to `main`. Use `--force-with-lease` on feature branches only.
 
 ### Adding a new tool (checklist)
 

--- a/skills/gen/SKILL.md
+++ b/skills/gen/SKILL.md
@@ -18,7 +18,7 @@ Generate an image using ComfyUI based on the user's prompt "$ARGUMENTS".
 
 3. **Generate the image.** Call `comfyui_generate_image` with the parsed parameters and `wait=True` so we block until completion.
 
-4. **Fetch the result.** Once generation completes, the response includes the output filename. Call `comfyui_get_image` with that filename and subfolder `"output"` to retrieve it.
+4. **Fetch the result.** The response is a dict envelope with keys `status` (expect `"completed"`), `prompt_id`, `outputs`, `elapsed_seconds`, and optionally `warnings`. `outputs` is a list of `{node_id, filename, subfolder}` entries — read the first entry's `filename` and `subfolder` and call `comfyui_get_image` with those. (Tip: pass `preview_format="webp"` and `preview_quality=80` to `comfyui_get_image` for a thumbnail instead of the full PNG — much cheaper context.)
 
 5. **Present the result.** Show the image and a summary of the generation parameters used (prompt, model, dimensions, steps, cfg).
 

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -6,10 +6,10 @@ description: Show recent ComfyUI generation history
 
 Show recent ComfyUI completions.
 
-Call `comfyui_get_history` and format the results as a table or list showing:
+Call `comfyui_get_history` and iterate `result["items"]` (the response is a pagination envelope: `{items, count, offset, limit, has_more, total}` where `total` is set only on the last page). For each item, show:
 
 - **Prompt ID**: the unique job identifier
 - **Status**: whether it completed successfully or failed
 - **Outputs**: filenames of generated images (if any)
 
-Show the most recent entries first. If the user wants to view a specific output, they can use `comfyui_get_image` with the filename.
+Show the most recent entries first. If the user wants to view a specific output, they can use `comfyui_get_image` with the filename. For a more unified view that also includes queued and currently-running jobs, use `comfyui_list_jobs` instead.

--- a/skills/models/SKILL.md
+++ b/skills/models/SKILL.md
@@ -8,6 +8,6 @@ List models available in ComfyUI. Filter type: "$ARGUMENTS".
 
 Call `comfyui_list_models` with the folder argument. If "$ARGUMENTS" is provided, use it as the folder type (e.g., "checkpoints", "loras", "vae", "controlnet", "upscale_models"). If no argument is given, default to `"checkpoints"`.
 
-Format the results as a clean list of model filenames. If the list is long, group by subfolder if applicable.
+The response is a pagination envelope `{items, total, offset, limit, has_more}` — iterate `result["items"]` for the model filenames. Format them as a clean list. If `has_more` is true, mention that there are additional results and the user can request a higher `limit` (max 100) or pass `offset` for the next page.
 
-To see all available model folder types, call `comfyui_list_model_folders`.
+To see all available model folder types, call `comfyui_list_model_folders` and iterate its `items` the same way.

--- a/skills/progress/SKILL.md
+++ b/skills/progress/SKILL.md
@@ -6,10 +6,10 @@ description: Show execution progress for a ComfyUI job
 
 Show progress for a specific ComfyUI job. Prompt ID: "$ARGUMENTS".
 
-Call `comfyui_get_progress` with the prompt_id from "$ARGUMENTS". Format the response showing:
+Call `comfyui_get_progress` with the prompt_id from "$ARGUMENTS". The response is a dict; format it showing:
 
-- **Current node**: which node is executing
-- **Progress**: step X of Y (percentage)
-- **Status**: running, completed, or failed
+- **Current node**: which node is executing (`current_node` field)
+- **Progress**: `step` X of `total_steps` Y (percentage)
+- **Status**: one of `queued`, `running`, `completed`, `error`, `interrupted` (mapped from the unified `/api/jobs/{id}` endpoint), or `unknown` if the job is not found
 
 If no prompt_id is provided, suggest the user check `/comfy:status` first to find active job IDs, or `/comfy:history` for recent completions.

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -10,18 +10,19 @@ Create and optionally run a ComfyUI workflow. Template or description: "$ARGUMEN
 
 1. **Pick a template.** If no specific template was requested, choose from the built-in template names accepted by `comfyui_create_workflow`: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The full list is also in `comfyui_create_workflow`'s docstring. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — *not* these MCP-built-in templates.)
 
-2. **Create the workflow.** Call `comfyui_create_workflow` with the chosen template name and any parameters the user specified (as a JSON string). For example:
+2. **Create the workflow.** Call `comfyui_create_workflow` with the chosen template name and any parameters the user specified as a JSON string. If the user didn't ask for overrides, omit `params` (it defaults to `""` = "use template defaults"). With overrides:
    ```
    create_workflow(template="txt2img", params='{"prompt": "a sunset", "width": 768}')
    ```
 
-3. **Validate the workflow.** Call `comfyui_validate_workflow` with the workflow JSON returned from step 2. Report any warnings or errors.
+3. **Validate the workflow.** Call `comfyui_validate_workflow` with the workflow JSON returned from step 2. The response is a dict `{valid, errors, warnings, node_count, pipeline}`. Report any entries in `errors` (blocking) and `warnings` (non-blocking).
 
 4. **Present the workflow.** Show a summary of what the workflow does (nodes, connections, key parameters). Offer the user two options:
-   - **Run it** — call `comfyui_run_workflow` with `wait=True`
+   - **Run it** — call `comfyui_run_workflow` with `wait=True`. The response is a dict envelope: `{status, prompt_id, outputs, elapsed_seconds, warnings?}`. Read `status` to confirm completion.
    - **Modify it** — use `comfyui_modify_workflow` to add/remove nodes or change parameters, then re-validate
 
 ## Notes
 
-- Use `comfyui_summarize_workflow` to get a readable overview of any workflow JSON.
+- Use `comfyui_summarize_workflow` for a human-readable text or Mermaid overview (`output_format="text"` or `"mermaid"`).
+- Use `comfyui_analyze_workflow` if you need the structured analysis as a dict (fields like `pipeline`, `models`, `parameters`) without parsing prose.
 - For simple text-to-image generation, `/comfy:gen` is faster.

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -65,11 +65,12 @@ ComfyUI workflows use a JSON format where each node is a key-value pair:
 
 ## Using the Workflow Tools
 
-1. **`comfyui_create_workflow`** — Start from a built-in template. The accepted template names are listed in the tool's docstring: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — a different set, not these MCP-built-in templates.)
-2. **`comfyui_modify_workflow`** — Add/remove nodes, change connections, update parameters on an existing workflow.
-3. **`comfyui_validate_workflow`** — Check for missing connections, unknown node types, and potential issues.
-4. **`comfyui_summarize_workflow`** — Get a human-readable description of what a workflow does.
-5. **`comfyui_run_workflow`** — Submit a workflow for execution. Use `wait=True` to block until done.
+1. **`comfyui_create_workflow`** — Start from a built-in template. Accepted template names are listed in the tool's docstring: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The `params` argument defaults to `""` (= "use template defaults"); pass a JSON string when you want overrides. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — a different set, not these MCP-built-in templates.)
+2. **`comfyui_modify_workflow`** — Add/remove nodes, change connections, update parameters on an existing workflow. Operations: `add_node`, `remove_node`, `set_input`, `connect`, `disconnect`. The docstring spells out each op's exact field shape. The call is atomic — if any operation fails, the call raises and the input workflow is unmodified.
+3. **`comfyui_validate_workflow`** — Returns `{valid, errors, warnings, node_count, pipeline}`. `errors` (list[str]) are blocking; `warnings` (list[str]) are non-blocking concerns like missing model files or suspicious inputs.
+4. **`comfyui_summarize_workflow`** — Human-readable overview. Pass `output_format="text"` (default) or `"mermaid"` for diagram markup.
+5. **`comfyui_analyze_workflow`** — Returns the analysis as a structured dict (`node_count`, `class_types`, `flow`, `models`, `parameters`, `pipeline`, `prompt_nodes`, `negative_nodes`). Use this when you want to read fields like `pipeline` programmatically; use `comfyui_summarize_workflow` for the human-readable rendering.
+6. **`comfyui_run_workflow`** — Submit a workflow for execution. Use `wait=True` to block until done. The response is always a dict envelope: `{status, prompt_id, outputs, elapsed_seconds, warnings?}` where `status` is one of `submitted` / `completed` / `interrupted` / `error` / `timeout`. With `wait=False` you get just `{status: "submitted", prompt_id, warnings?}` — poll `comfyui_get_progress` or `comfyui_get_job` to follow up.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

Three bundled repo-hygiene cleanups:

### 1. CLAUDE.md additions

- **Operational Status callout** near the top — documents the CI-down window (until 2026-06-01) and the local-verify + `--admin` merge workaround. Self-stales after the date.
- **Eval workflow rules (#22-25)** — codifies the Phase 4 regression gate, the `compare_evals.py` diff workflow, tag requirement on new JSONL questions, and "don't commit `.eval` logs".
- **Release & PR workflow (#26-30)** — squash-merge convention, conventional commit bodies with the `Co-Authored-By` trailer, the three coordinated edits a release needs (version + CHANGELOG section + link reference), the manual `gh release create` step (we hit this for 2.0.0 and 2.1.0), no force-push to main.

### 2. Skill v2 drift fixes

Six of eight `skills/*/SKILL.md` files touched (status, troubleshooting had no drift):

| Skill | Drift fixed |
|---|---|
| `gen/` | Spell out the v2 dict envelope (`status`/`prompt_id`/`outputs`/`elapsed_seconds`/`warnings`); mention `preview_format`/`preview_quality` on `comfyui_get_image` |
| `history/` | Iterate `result["items"]` (pagination envelope); point at `comfyui_list_jobs` for unified queue+history view |
| `models/` | Iterate `result["items"]` for paginated `list_models` / `list_model_folders` |
| `progress/` | Update status mapping to v2 (`queued`/`running`/`completed`/`error`/`interrupted`) from the unified `/api/jobs/{id}` endpoint |
| `workflow/` | New `params=""` default; spell out `validate`'s result dict shape and `run_workflow`'s wait envelope; mention `comfyui_analyze_workflow` |
| `workflows/` | Full v2 tool reference — `modify_workflow` op atomicity, `validate` keys, `summarize`'s `output_format`, `analyze_workflow` as new item #5, `run_workflow` wait-envelope `status` values |

### 3. Plugin version bump

`.claude-plugin/plugin.json`: `1.0.0` → `2.1.0` to match the released package.

## Test plan

- [x] `pre-commit run --files <changed>` clean (no code changes; markdown + JSON)
- [x] CLAUDE.md rule numbering stays sequential (1-30) and section structure intact
- [x] All 6 SKILL.md frontmatter blocks unchanged
- [ ] CI (down through 2026-06-01) — admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)