### PR TITLE
Skill prompts: refine error handling, decision guides, and nesting

### DIFF
--- a/skills/gen/SKILL.md
+++ b/skills/gen/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: gen
 description: Generate an image with ComfyUI from a text prompt
 ---
 
@@ -8,13 +9,18 @@ Generate an image using ComfyUI based on the user's prompt "$ARGUMENTS".
 
 ## Steps
 
-1. **Parse the prompt.** Extract any explicit parameters (dimensions, steps, cfg, model name) from the user's request. Use these defaults for anything not specified:
+1. **Parse the prompt.** Extract any explicit parameters (dimensions, steps, cfg, model name) from the user's request. Reject and ask for clarification only in these specific cases:
+   - The prompt is empty or whitespace-only
+   - The prompt is a question or meta-request rather than a scene description (e.g., "what can you do?", "how does this work?")
+   - The user passed a parameter outside its valid range (steps < 1, cfg < 0, width/height not divisible by 8)
+
+   Otherwise, apply these defaults for the listed parameters (and only these) when not specified:
    - width: 512, height: 512
    - steps: 20
    - cfg: 7.0
    - negative_prompt: "bad quality, blurry"
 
-2. **Select a model.** If the user didn't specify a model, call `comfyui_list_models` with folder `"checkpoints"` and suggest one from the results. Ask the user to confirm before proceeding, or let them pick a different one.
+2. **Select a model.** If the user specified a model name, use it. Otherwise, call `comfyui_list_models` with folder `"checkpoints"`, pick one from the returned `items`, and ask the user to confirm before proceeding (offer to swap if they want a different one).
 
 3. **Generate the image.** Call `comfyui_generate_image` with the parsed parameters and `wait=True` so we block until completion.
 

--- a/skills/history/SKILL.md
+++ b/skills/history/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: history
 description: Show recent ComfyUI generation history
 ---
 
@@ -6,10 +7,11 @@ description: Show recent ComfyUI generation history
 
 Show recent ComfyUI completions.
 
-Call `comfyui_get_history` and iterate `result["items"]` (the response is a pagination envelope: `{items, count, offset, limit, has_more, total}` where `total` is set only on the last page). For each item, show:
+1. **Fetch history.** Call `comfyui_get_history`. The response is a pagination envelope: `{items, count, offset, limit, has_more, total}` where `total` is set only on the last page.
 
-- **Prompt ID**: the unique job identifier
-- **Status**: whether it completed successfully or failed
-- **Outputs**: filenames of generated images (if any)
+2. **Display results.** The MCP returns items in most-recent-first order — display them in the returned order; do not re-sort client-side. Iterate `result["items"]` and for each item show:
+   - **Prompt ID**: the unique job identifier
+   - **Status**: whether it completed successfully or failed
+   - **Outputs**: filenames of generated images (if any)
 
-Show the most recent entries first. If the user wants to view a specific output, they can use `comfyui_get_image` with the filename. For a more unified view that also includes queued and currently-running jobs, use `comfyui_list_jobs` instead.
+3. **Follow-up options.** If the user wants to view a specific output, they can use `comfyui_get_image` with the filename. For a more unified view that also includes queued and currently-running jobs, use `comfyui_list_jobs` instead.

--- a/skills/models/SKILL.md
+++ b/skills/models/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: models
 description: List available ComfyUI models, optionally filtered by type
 ---
 
@@ -6,8 +7,14 @@ description: List available ComfyUI models, optionally filtered by type
 
 List models available in ComfyUI. Filter type: "$ARGUMENTS".
 
-Call `comfyui_list_models` with the folder argument. If "$ARGUMENTS" is provided, use it as the folder type (e.g., "checkpoints", "loras", "vae", "controlnet", "upscale_models"). If no argument is given, default to `"checkpoints"`.
+1. **Determine the folder type.**
+   - If "$ARGUMENTS" is provided, use it as the folder type. Common values: `"checkpoints"`, `"loras"`, `"vae"`, `"controlnet"`, `"upscale_models"`.
+   - If "$ARGUMENTS" is not provided, default to `"checkpoints"`.
+   - If step 2 fails because the folder type is invalid, recover by:
+     1. Printing `"Invalid folder type. Valid options:"`
+     2. Calling `comfyui_list_model_folders` and listing its `items` as the valid options
+     3. Asking the user to retry with one of those
 
-The response is a pagination envelope `{items, total, offset, limit, has_more}` — iterate `result["items"]` for the model filenames. Format them as a clean list. If `has_more` is true, mention that there are additional results and the user can request a higher `limit` (max 100) or pass `offset` for the next page.
+2. **Call `comfyui_list_models`** with the determined folder type.
 
-To see all available model folder types, call `comfyui_list_model_folders` and iterate its `items` the same way.
+3. **Process the response.** The response is a pagination envelope `{items, total, offset, limit, has_more}` — iterate `result["items"]` for the model filenames. Format them as a clean list. If `has_more` is true, mention that there are additional results and the user can request a higher `limit` (max 100) or pass `offset` for the next page.

--- a/skills/progress/SKILL.md
+++ b/skills/progress/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: progress
 description: Show execution progress for a ComfyUI job
 ---
 
@@ -6,10 +7,11 @@ description: Show execution progress for a ComfyUI job
 
 Show progress for a specific ComfyUI job. Prompt ID: "$ARGUMENTS".
 
-Call `comfyui_get_progress` with the prompt_id from "$ARGUMENTS". The response is a dict; format it showing:
+1. **Get the prompt_id.** Extract it from "$ARGUMENTS". If "$ARGUMENTS" is empty or contains no recognizable id, suggest the user run `/comfy:status` first to find active job IDs, or `/comfy:history` for recent completions, and stop here.
 
-- **Current node**: which node is executing (`current_node` field)
-- **Progress**: `step` X of `total_steps` Y (percentage)
-- **Status**: one of `queued`, `running`, `completed`, `error`, `interrupted` (mapped from the unified `/api/jobs/{id}` endpoint), or `unknown` if the job is not found
+2. **Fetch progress.** Call `comfyui_get_progress` with the prompt_id. Do not pre-validate the id format — the tool returns `status="unknown"` if the job is not found, which step 3 surfaces to the user.
 
-If no prompt_id is provided, suggest the user check `/comfy:status` first to find active job IDs, or `/comfy:history` for recent completions.
+3. **Format the response.** The response is a dict. Format it to include the following fields:
+   - **Current node**: which node is executing (`current_node` field)
+   - **Progress**: `step` X of `total_steps` Y (percentage)
+   - **Status**: one of `queued`, `running`, `completed`, `error`, `interrupted` (mapped from the unified `/api/jobs/{id}` endpoint), or `unknown` if the job is not found

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: status
 description: Show ComfyUI queue status with running and pending jobs
 ---
 
@@ -11,4 +12,6 @@ Call `comfyui_get_queue` and format the response as:
 - **Running jobs**: count and list of prompt IDs currently executing
 - **Pending jobs**: count and list of prompt IDs waiting in queue
 
-If both lists are empty, report that the queue is idle.
+If `comfyui_get_queue` returns an error or unexpected data, respond with an appropriate error message indicating the issue.
+
+If both the count of running jobs and the count of pending jobs are zero, report that the queue is idle.

--- a/skills/troubleshooting/SKILL.md
+++ b/skills/troubleshooting/SKILL.md
@@ -1,9 +1,11 @@
 ---
-name: comfyui-troubleshooting
+name: troubleshooting
 description: Troubleshooting guide for ComfyUI MCP connection issues, model errors, workflow failures, and security warnings. Use when users encounter errors or unexpected behavior.
 ---
 
 # ComfyUI Troubleshooting Guide
+
+Each section below is independent. Find the section whose symptom matches the error you are seeing and work through only those checks.
 
 ## Connection Failures
 
@@ -58,7 +60,7 @@ description: Troubleshooting guide for ComfyUI MCP connection issues, model erro
 
 **What to do:**
 1. Review the flagged nodes. The warning lists which node types were detected and why.
-2. If you trust the nodes, you can proceed (audit mode) or add them to an allowlist in config.
+2. If you have verified the node's functionality and source code to ensure it is safe to execute, you can proceed (audit mode) or add it to an allowlist in config.
 3. Use `comfyui_audit_dangerous_nodes` to scan all installed nodes proactively.
 4. Change mode in `~/.comfyui-mcp/config.yaml`: `security.mode: "audit"` or `"enforce"`.
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,19 +1,22 @@
 ---
+name: workflow
 description: Create a ComfyUI workflow from a template
 ---
 
 # Create Workflow
 
-Create and optionally run a ComfyUI workflow. Template or description: "$ARGUMENTS".
+Create and optionally run a ComfyUI workflow. Template or description provided by the user as input: "$ARGUMENTS".
 
 ## Steps
 
-1. **Pick a template.** If no specific template was requested, choose from the built-in template names accepted by `comfyui_create_workflow`: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The full list is also in `comfyui_create_workflow`'s docstring. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — *not* these MCP-built-in templates.)
+1. **Pick a template.** If no specific template was requested, choose from the built-in template names accepted by `comfyui_create_workflow`: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The full list is also in `comfyui_create_workflow`'s docstring. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — *not* these MCP-built-in templates.) If the user provides a template name that is not in this list, respond with an error message and list the valid options above.
 
-2. **Create the workflow.** Call `comfyui_create_workflow` with the chosen template name and any parameters the user specified as a JSON string. If the user didn't ask for overrides, omit `params` (it defaults to `""` = "use template defaults"). With overrides:
-   ```
-   create_workflow(template="txt2img", params='{"prompt": "a sunset", "width": 768}')
-   ```
+2. **Create the workflow.**
+   - If the user did not specify any parameter overrides, call `comfyui_create_workflow` with only the template name (omit `params`; it defaults to `""`, which applies the predefined settings for the selected template).
+   - If the user specified overrides (e.g., prompt, dimensions), pass them as a JSON string in the `params` argument:
+     ```
+     create_workflow(template="txt2img", params='{"prompt": "a sunset", "width": 768}')
+     ```
 
 3. **Validate the workflow.** Call `comfyui_validate_workflow` with the workflow JSON returned from step 2. The response is a dict `{valid, errors, warnings, node_count, pipeline}`. Report any entries in `errors` (blocking) and `warnings` (non-blocking).
 

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: comfyui-workflows
+name: workflows
 description: Knowledge about ComfyUI workflow API format, node connections, and common patterns. Use when helping users build, modify, or understand workflows.
 ---
 
@@ -65,7 +65,18 @@ ComfyUI workflows use a JSON format where each node is a key-value pair:
 
 ## Using the Workflow Tools
 
-1. **`comfyui_create_workflow`** — Start from a built-in template. Accepted template names are listed in the tool's docstring: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The `params` argument defaults to `""` (= "use template defaults"); pass a JSON string when you want overrides. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — a different set, not these MCP-built-in templates.)
+**Quick decision guide** — pick the tool by what you need to do:
+
+| Goal | Tool |
+|------|------|
+| Build a new workflow from scratch | `comfyui_create_workflow` |
+| Modify an existing workflow | `comfyui_modify_workflow` |
+| Understand a workflow (human-readable text or Mermaid) | `comfyui_summarize_workflow` |
+| Understand a workflow (machine-readable dict) | `comfyui_analyze_workflow` |
+| Check a workflow for errors before running | `comfyui_validate_workflow` |
+| Execute a workflow | `comfyui_run_workflow` |
+
+1. **`comfyui_create_workflow`** — Start from a built-in template. Accepted template names are listed in the tool's docstring: `txt2img`, `img2img`, `upscale`, `inpaint`, `txt2vid_animatediff`, `txt2vid_wan`, `controlnet_canny`, `controlnet_depth`, `controlnet_openpose`, `ip_adapter`, `lora_stack`, `face_restore`, `flux_txt2img`, `sdxl_txt2img`. The `params` argument defaults to `""`, which applies the predefined settings for the selected template (e.g., default dimensions, steps, and cfg values baked into that template); pass a JSON string when you want overrides. (Note: `comfyui_list_workflows` returns server-side `/workflow_templates` from front-end packages — a different set, not these MCP-built-in templates.)
 2. **`comfyui_modify_workflow`** — Add/remove nodes, change connections, update parameters on an existing workflow. Operations: `add_node`, `remove_node`, `set_input`, `connect`, `disconnect`. The docstring spells out each op's exact field shape. The call is atomic — if any operation fails, the call raises and the input workflow is unmodified.
 3. **`comfyui_validate_workflow`** — Returns `{valid, errors, warnings, node_count, pipeline}`. `errors` (list[str]) are blocking; `warnings` (list[str]) are non-blocking concerns like missing model files or suspicious inputs.
 4. **`comfyui_summarize_workflow`** — Human-readable overview. Pass `output_format="text"` (default) or `"mermaid"` for diagram markup.


### PR DESCRIPTION
## Summary

Builds on the user's working-tree edits to all 8 SKILL.md files (added `name:` slugs so all invocations are uniformly `/comfy:<slug>`, converted prose into numbered steps, inserted explicit error branches) with six prompt-engineering refinements identified via the `prompt-engineering-patterns` skill audit.

## Refinements applied

| # | File | Change | Why |
|---|------|--------|-----|
| 1 | `gen/` step 1 | "nonsensical input" → three specific failure modes (empty prompt / meta-question / out-of-range param) | "Nonsensical" was undefined and LLMs would interpret it inconsistently across runs. Per best-practice *Be Specific*. |
| 2 | `gen/` step 2 | Nested `1-4` sub-numbering replaced with a single sentence | Dual numbering (`2`/`2.1`/`2.2`) creates ambiguity; some LLMs flatten this. |
| 3 | `history/` step 2 | Removed "sort entries by completion time" instruction | Asked the LLM to client-side sort by an unnamed field. The MCP returns most-recent-first; just trust the API order. |
| 4 | `progress/` step 1 | Dropped "invalid or malformed prompt_id" pre-validation | Prompt IDs are UUIDs — no client-side validation possible. Step 3 already surfaces `status="unknown"` for not-found jobs. Single source of failure. |
| 5 | `models/` step 1 | Invalid-folder branch split from one mixed-action bullet into an explicit 3-step recovery sequence | Per Pattern 5 (Error Recovery): separating "print error" from "make tool call" keeps the LLM from dropping either step. |
| 6 | `workflows/` | "Quick decision guide" paragraph → 6-row table (goal → tool) | Skimmable; surfaces `summarize` vs. `analyze` as parallel choices instead of buried in prose. |

## What was preserved

- All `name:` slugs (`gen`, `history`, `models`, `progress`, `status`, `troubleshooting`, `workflow`, `workflows`) so the namespaced `/comfy:<slug>` invocation style stays uniform.
- All the user's numbered-step structure and explicit error branches that were already correct.
- The verified-source security language in `troubleshooting/`.
- The "each section is independent" preface in `troubleshooting/`.

## Test plan

- [x] `pre-commit run --files <changed>` clean (no code changes; markdown only)
- [x] All 8 SKILL.md frontmatter blocks intact (`name:` slug + `description:`)
- [x] Total diff: 8 files, +62 / -26
- [ ] CI (down through 2026-06-01) — admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)