### PR TITLE
README: surface the Claude plugin path more prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A secure MCP (Model Context Protocol) server for [ComfyUI](https://github.com/comfyanonymous/ComfyUI). Enables AI assistants like Claude to generate images, run workflows, and manage jobs through ComfyUI — with built-in security controls that existing ComfyUI MCP servers lack.
 
+> **Using Claude?** This repo also ships as a Claude Code plugin — 8 `/comfy:*` slash commands (`/comfy:gen`, `/comfy:workflow`, `/comfy:troubleshooting`, …) and a `PostToolUse` security hook, all pre-wired to the MCP server. One command to install: `claude plugin install .` See [Install as a Claude plugin](#what-the-plugin-gives-you) for the full reference + worked end-to-end example.
+
 ## Why this exists
 
 Every existing ComfyUI MCP server is a thin passthrough to ComfyUI's API with no security guardrails. They allow arbitrary workflow execution (including malicious custom nodes that run `eval`/`exec`), have no input validation, no file path sanitization, no rate limiting, and no audit trail.
@@ -81,6 +83,8 @@ Previously these tools returned either a free-form sentence (`wait=False`) or a 
 - A running ComfyUI instance (local or remote)
 
 ### Install
+
+> **Claude Code users:** the fastest path is the plugin — see [Install as a Claude plugin](#install-as-a-claude-plugin-from-this-repo) below. It wires the MCP server + slash commands + security hook in one step. The options below are for everyone else (raw MCP wiring, Docker, source installs).
 
 #### Option A: From PyPI
 


### PR DESCRIPTION
## Summary

The "Install as a Claude plugin" section was buried at line 211 under Quick Start → Add to Claude Code → Install as a Claude plugin. Anyone scanning the README would miss that the repo ships pre-wired as a one-command Claude Code plugin — not just a raw MCP server they have to wire themselves.

Two surface-level placements added (+4 lines, no restructuring of existing content):

1. **Hero callout** right after the project tagline. Names three of the most-used slash commands inline (`/comfy:gen`, `/comfy:workflow`, `/comfy:troubleshooting`) and deep-links to the worked end-to-end example in "What the plugin gives you".

2. **Breadcrumb at the top of Install** telling Claude Code users to jump straight to the plugin section, and clarifying that the PyPI / source / Docker options below are for everyone else wiring the raw MCP server themselves.

The plugin section itself was already documented thoroughly in PR #94 — this PR is purely about discoverability.

## Test plan

- [x] `pre-commit run --files README.md` clean
- [x] Both anchor targets exist (`#install-as-a-claude-plugin-from-this-repo` and `#what-the-plugin-gives-you`)
- [ ] CI (down through 2026-06-01) — admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)