### PR TITLE
Plugin manifest: add license/homepage/repository + document github-url install

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,8 @@
 {
   "name": "comfy",
   "description": "ComfyUI image generation via MCP with slash commands and skills",
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/hybridindie/comfyui_mcp",
+  "repository": "https://github.com/hybridindie/comfyui_mcp"
 }

--- a/README.md
+++ b/README.md
@@ -210,15 +210,19 @@ The MCP server communicates over stdio. Add one of the following configurations 
 
 ### Install as a Claude plugin (from this repo)
 
-This repository includes a Claude plugin manifest at `.claude-plugin/plugin.json`.
+This repository ships as a complete Claude Code plugin — manifest at `.claude-plugin/plugin.json`. Two install paths:
 
 ```bash
+# Direct from GitHub (recommended — pulls the published tag):
+claude plugin install https://github.com/hybridindie/comfyui_mcp
+
+# Or from a local clone (for development or unreleased changes):
 claude plugin install .
 ```
 
-Plugin-related files currently included in this repo:
+Plugin-related files in this repo:
 
-- `.claude-plugin/plugin.json` (plugin manifest)
+- `.claude-plugin/plugin.json` (plugin manifest — name, version, license, homepage)
 - `.mcp.json` (MCP server bootstrap config)
 - `hooks/` (security warning hook)
 - `skills/` (slash-command skills)


### PR DESCRIPTION
## Summary

Two small changes preparing the plugin for Claude marketplace submission:

### 1. Plugin manifest metadata

`.claude-plugin/plugin.json` now has the three optional fields the marketplace recommends, all mirrored from the existing `pyproject.toml` URLs and the `LICENSE` file:

```json
{
  "name": "comfy",
  "description": "ComfyUI image generation via MCP with slash commands and skills",
  "version": "2.1.0",
  "license": "MIT",
  "homepage": "https://github.com/hybridindie/comfyui_mcp",
  "repository": "https://github.com/hybridindie/comfyui_mcp"
}
```

### 2. README: github-url install

Promotes `claude plugin install <github-url>` as the primary install path; the local `claude plugin install .` becomes the dev-mode fallback:

```bash
claude plugin install https://github.com/hybridindie/comfyui_mcp
# or for dev:
claude plugin install .
```

## Marketplace submission

Once this merges, the plugin is ready to list. Submission URL: https://clau.de/plugin-directory-submission

## Test plan

- [x] `.claude-plugin/plugin.json` parses as valid JSON
- [x] `pre-commit run --files <changed>` clean
- [x] Both install paths documented in the README plugin section
- [ ] CI (down through 2026-06-01) — admin-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)