### PR TITLE
Run release workflows on self-hosted runner; keep PR CI on ubuntu-latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
 
   docker:
     needs: [ci]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, hybridindie]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,7 +11,7 @@ jobs:
 
   build:
     needs: [ci]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, hybridindie]
     permissions:
       contents: read
 
@@ -55,7 +55,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, hybridindie]
     environment:
       name: pypi
     permissions:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          python3 - <<'PY'
+          uv run --no-project --python 3.12 python - <<'PY'
           import os
           import tomllib
 


### PR DESCRIPTION
Moves the **release** workflows to the self-hosted runner while deliberately keeping the **PR-triggered** CI on GitHub-hosted runners.

## Changes

- `docker.yml` — `docker` build/push job → `[self-hosted, linux, hybridindie]`
- `pypi.yml` — `build` and `publish` jobs → `[self-hosted, linux, hybridindie]`
- `ci.yml` — **unchanged, stays on `ubuntu-latest`**

## Why split it this way

`docker.yml` and `pypi.yml` only trigger on **trusted refs** (tag push, `release: published`, push to `main`), so fork-submitted code never executes on the host.

`ci.yml` is triggered by `pull_request` on a **public** repo. Pointing that at a persistent self-hosted runner would let any fork PR run arbitrary code on the `hybridindie` host (`uv run pytest` executes the PR's own code) — the classic self-hosted-runner RCE vector GitHub warns against. So PR CI stays on `ubuntu-latest`.

## Assumption / heads-up

This assumes GitHub-hosted runner billing is restored (the prior "CI down until 2026-06-01" window has passed). If `ubuntu-latest` is still unavailable, PR CI won't run — in that case the right fix is ephemeral self-hosted runners + "require approval for outside collaborators", **not** a persistent runner on the `pull_request` trigger. Happy to set that up instead if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)