### PR TITLE
Add K8s manifests for the self-hosted release runner

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,63 @@
+# Self-hosted GitHub Actions runner (K3s)
+
+Runs the `docker` and `pypi` release jobs, which target
+`runs-on: [self-hosted, linux, hybridindie]`. PR CI stays on GitHub-hosted
+`ubuntu-latest` (see `.github/workflows/ci.yml`).
+
+## What's deployed
+
+`github-runner.yaml` — a Deployment in the `ci` namespace with two containers:
+
+- **dind** — `docker:27-dind` (privileged) providing the Docker daemon the
+  buildx/QEMU multi-arch build needs.
+- **runner** — `myoung34/github-runner` registered to this repo with the
+  `hybridindie` label, talking to the daemon via `DOCKER_HOST=tcp://localhost:2375`.
+
+The runner is **persistent** (no `EPHEMERAL` env — myoung34 treats any non-empty
+value, even `"false"`, as enabled, so it must be omitted).
+
+## Registration token vs. PAT (durability)
+
+The Deployment currently authenticates with a **registration token** stored in
+the `github-actions-runner` secret under `RUNNER_TOKEN`. A registration token is
+only used **once**, at first registration; afterward the runner authenticates
+with its own stored credentials, so token expiry does not matter **while the pod
+keeps running**.
+
+⚠️ **A registration token expires ~1 hour after it is minted.** If the pod is
+recreated after that (node reboot, eviction, image update), the runner cannot
+re-register and release CI silently breaks again.
+
+**Durable fix:** put a GitHub PAT (classic, `repo` scope — or a fine-grained
+token with Administration: read/write) into the secret and switch the env var:
+
+```bash
+kubectl create secret generic github-actions-runner -n ci \
+  --from-literal=ACCESS_TOKEN=<YOUR_PAT> \
+  --dry-run=client -o yaml | kubectl apply -f -
+# then in github-runner.yaml, replace the RUNNER_TOKEN env with:
+#   - name: ACCESS_TOKEN
+#     valueFrom: { secretKeyRef: { name: github-actions-runner, key: ACCESS_TOKEN } }
+kubectl rollout restart deployment/github-runner -n ci
+```
+
+With `ACCESS_TOKEN` (a PAT) the image mints fresh registration tokens on every
+start, so the runner survives restarts indefinitely.
+
+## Re-mint a registration token (if not using a PAT)
+
+```bash
+TOKEN=$(gh api -X POST repos/hybridindie/comfyui_mcp/actions/runners/registration-token --jq '.token')
+kubectl create secret generic github-actions-runner -n ci \
+  --from-literal=ACCESS_TOKEN=unused --from-literal=RUNNER_TOKEN="$TOKEN" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout restart deployment/github-runner -n ci
+```
+
+## Health checks
+
+```bash
+kubectl get pods -n ci -l app=github-runner
+kubectl logs -n ci -l app=github-runner -c runner --tail=20
+gh api repos/hybridindie/comfyui_mcp/actions/runners --jq '.runners[] | {name,status,busy}'
+```

--- a/deploy/k8s/github-runner.yaml
+++ b/deploy/k8s/github-runner.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-runner
+  namespace: ci
+  labels:
+    app: github-runner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: github-runner
+  template:
+    metadata:
+      labels:
+        app: github-runner
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        # Docker-in-Docker sidecar: provides the daemon the buildx/QEMU steps need.
+        - name: dind
+          image: docker:27-dind
+          securityContext:
+            privileged: true
+          env:
+            - name: DOCKER_TLS_CERTDIR    # disable TLS -> daemon listens on plain tcp 2375
+              value: ""
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "4"
+              memory: "6Gi"
+          volumeMounts:
+            - name: docker-data
+              mountPath: /var/lib/docker
+        # GitHub Actions runner: registers with the repo, runs jobs, talks to the dind sidecar.
+        - name: runner
+          image: myoung34/github-runner:2.334.0-ubuntu-noble
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2375"
+            - name: REPO_URL
+              value: "https://github.com/hybridindie/comfyui_mcp"
+            - name: RUNNER_SCOPE
+              value: "repo"
+            - name: LABELS
+              value: "hybridindie"        # self-hosted + Linux/X64 are added automatically
+            - name: RUNNER_NAME_PREFIX
+              value: "k3s"
+            # NOTE: do NOT set EPHEMERAL — myoung34 treats any non-empty value
+            # (even "false") as enabled. Omitting it => persistent runner.
+            # ACCESS_TOKEN is a PAT (repo scope); the image mints fresh
+            # registration tokens on every start, so the runner survives restarts.
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-actions-runner
+                  key: ACCESS_TOKEN
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          volumeMounts:
+            - name: work
+              mountPath: /runner/_work
+      volumes:
+        - name: docker-data
+          emptyDir: {}
+        - name: work
+          emptyDir: {}


### PR DESCRIPTION
Captures the infrastructure that backs `runs-on: [self-hosted, linux, hybridindie]` (the Docker + PyPI release workflows) as version-controlled manifests. The runner is already deployed and validated — this just makes it reproducible.

## Contents

- **`deploy/k8s/github-runner.yaml`** — Deployment in the `ci` namespace:
  - `runner` — persistent `myoung34/github-runner` (label `hybridindie`), auth via PAT in the `github-actions-runner` secret (`ACCESS_TOKEN`) so it auto-re-registers across pod restarts.
  - `dind` — privileged `docker:27-dind` sidecar; runner reaches it via `DOCKER_HOST=tcp://localhost:2375` for the multi-arch (`amd64`+`arm64`) buildx build.
- **`deploy/k8s/README.md`** — token setup, registration-token-vs-PAT durability notes, re-mint commands, and health checks.

## Security

No secrets in the manifest — the PAT is read via `secretKeyRef`. Verified with `grep -r ghp_ deploy/` (clean).

## Validation already done

- Runner registered online with labels `self-hosted, Linux, X64, hybridindie`.
- #105's `docker` run went fully green on it (multi-arch buildx v4 build pushed to ghcr).
- Pod-kill test confirmed automatic PAT-based re-registration (durability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)