### PR TITLE
Add resources and prompts for read-only state browsing (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,30 @@ The `comfyui_download_model` tool always sends a `previewFile` field (required b
 | `comfyui_upload_mask` | Upload a mask image to ComfyUI. Path-sanitized. Params: filename, mask_data, original_image, subfolder, original_subfolder, `destination="input"\|"output"\|"temp"` (default `input`), `overwrite` (default False — ComfyUI auto-renames duplicates). |
 | `comfyui_get_workflow_from_image` | Extract embedded workflow and prompt metadata from a ComfyUI-generated PNG. |
 
+### Resources
+
+Read-only state the LLM can browse by URI without a tool call. Templated
+resources inherit FastMCP 4's built-in path-traversal screening.
+
+| URI | Description |
+|-----|-------------|
+| `comfyui://models/{folder}` | List models in a folder (checkpoints, loras, vae, etc.). Path-traversal in `{folder}` is screened. |
+| `comfyui://nodes/installed` | Sorted list of all available ComfyUI node class types from `/object_info`. |
+| `comfyui://queue` | Current queue state — running and pending job counts. |
+| `comfyui://system` | Whitelisted system info: ComfyUI version, GPU VRAM, queue counts. Sensitive fields (hostname, OS, CPU, paths) excluded. |
+
+### Prompts
+
+Reusable, parameterized prompt recipes for the built-in workflow templates.
+Return a plain string the LLM can use as guidance.
+
+| Prompt | Description |
+|--------|-------------|
+| `txt2img_prompt` | Text-to-image recipe. Params: `prompt`, `style="photorealistic"`. |
+| `img2img_prompt` | Image-to-image recipe. Params: `image`, `prompt`, `style="photorealistic"`. |
+| `inpaint_prompt` | Inpaint recipe. Params: `image`, `mask`, `prompt`, `style="photorealistic"`. |
+| `upscale_prompt` | Upscale recipe. Params: `image`, `upscale_model="RealESRGAN_x4plus.pth"`. |
+
 ### Deliberately not exposed
 
 These ComfyUI endpoints are **never** proxied due to security risks:

--- a/src/comfyui_mcp/prompts.py
+++ b/src/comfyui_mcp/prompts.py
@@ -1,0 +1,162 @@
+"""MCP prompts: reusable, parameterized prompt templates for the LLM.
+
+Prompts expose the built-in workflow templates (txt2img, img2img, inpaint,
+upscale) as recipes the LLM can retrieve. Per architecture.md "Resources and
+prompts", prompt functions return a plain string (auto-wrapped as a user
+message) — not mcp.types.PromptMessage or raw role/content dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+
+
+def register_prompts(
+    mcp: FastMCP,
+    client: ComfyUIClient,
+    audit: AuditLogger,
+    limiter: RateLimiter,
+    sanitizer: PathSanitizer,
+) -> dict[str, Any]:
+    """Register workflow-template prompt recipes.
+
+    Returns a dict mapping prompt names to the underlying async functions so
+    tests can call them directly (mirrors the register_*_tools() contract).
+    """
+    prompt_fns: dict[str, Any] = {}
+
+    @mcp.prompt(
+        name="txt2img_prompt",
+        description=(
+            "Generate a text-to-image workflow recipe for a given style. "
+            "Returns guidance the caller can pass to comfyui_generate_image."
+        ),
+    )
+    async def txt2img_prompt(prompt: str, style: str = "photorealistic") -> str:
+        """Produce a txt2img recipe for the given prompt and style.
+
+        Args:
+            prompt: The text description of the image to generate.
+            style: The visual style to target (default: photorealistic).
+        """
+        limiter.check("prompt_txt2img")
+        await audit.async_log(tool="prompt_txt2img", action="called", extra={"style": style})
+        return (
+            f"Use comfyui_generate_image to generate an image.\n\n"
+            f"Prompt: {prompt}\n"
+            f"Target style: {style}.\n"
+            f"For {style} results, prefer a {style}-appropriate sampler/steps "
+            f"combination — use comfyui_get_model_presets to look up the "
+            f"recommended settings for your model family if unsure."
+        )
+
+    prompt_fns["txt2img_prompt"] = txt2img_prompt
+
+    @mcp.prompt(
+        name="img2img_prompt",
+        description=(
+            "Generate an image-to-image workflow recipe. The caller must "
+            "have already uploaded the input image via comfyui_upload_image."
+        ),
+    )
+    async def img2img_prompt(image: str, prompt: str, style: str = "photorealistic") -> str:
+        """Produce an img2img recipe given an uploaded image and a transform prompt.
+
+        Args:
+            image: Filename of the image in ComfyUI's input directory.
+            prompt: Text description guiding the transformation.
+            style: Visual style to target (default: photorealistic).
+        """
+        limiter.check("prompt_img2img")
+        await audit.async_log(
+            tool="prompt_img2img", action="called", extra={"style": style, "image": image}
+        )
+        return (
+            f"Use comfyui_transform_image to transform an existing image.\n\n"
+            f"Image: {image}\n"
+            f"Prompt: {prompt}\n"
+            f"Target style: {style}.\n"
+            f"Set the `strength` parameter based on how far to deviate from "
+            f"the input — lower values (0.3-0.5) keep more of the original; "
+            f"higher values (0.7-0.9) allow more change."
+        )
+
+    prompt_fns["img2img_prompt"] = img2img_prompt
+
+    @mcp.prompt(
+        name="inpaint_prompt",
+        description=(
+            "Generate an inpaint workflow recipe. The caller must have "
+            "already uploaded both the input image and mask."
+        ),
+    )
+    async def inpaint_prompt(
+        image: str,
+        mask: str,
+        prompt: str,
+        style: str = "photorealistic",
+    ) -> str:
+        """Produce an inpaint recipe given an uploaded image, mask, and prompt.
+
+        Args:
+            image: Filename of the image in ComfyUI's input directory.
+            mask: Filename of the mask (white=inpaint, black=keep).
+            prompt: Text description for the inpainted region.
+            style: Visual style to target (default: photorealistic).
+        """
+        limiter.check("prompt_inpaint")
+        await audit.async_log(
+            tool="prompt_inpaint",
+            action="called",
+            extra={"style": style, "image": image, "mask": mask},
+        )
+        return (
+            f"Use comfyui_inpaint_image to regenerate regions of an image.\n\n"
+            f"Image: {image}\n"
+            f"Mask: {mask} (white regions will be regenerated)\n"
+            f"Prompt: {prompt}\n"
+            f"Target style: {style}.\n"
+            f"White regions in the mask indicate areas to regenerate. Set "
+            f"`strength` (denoise) higher (0.8-1.0) for full replacement of the "
+            f"masked region."
+        )
+
+    prompt_fns["inpaint_prompt"] = inpaint_prompt
+
+    @mcp.prompt(
+        name="upscale_prompt",
+        description=(
+            "Generate an upscaling workflow recipe. The caller must have "
+            "already uploaded the input image."
+        ),
+    )
+    async def upscale_prompt(image: str, upscale_model: str = "RealESRGAN_x4plus.pth") -> str:
+        """Produce an upscale recipe for an uploaded image.
+
+        Args:
+            image: Filename of the image in ComfyUI's input directory.
+            upscale_model: Name of the upscale model file (default: RealESRGAN_x4plus.pth).
+        """
+        limiter.check("prompt_upscale")
+        await audit.async_log(
+            tool="prompt_upscale", action="called", extra={"image": image, "model": upscale_model}
+        )
+        return (
+            f"Use comfyui_upscale_image to upscale an existing image.\n\n"
+            f"Image: {image}\n"
+            f"Upscale model: {upscale_model}\n"
+            f"The scale factor is determined by the upscale model "
+            f"(e.g. RealESRGAN_x4plus = 4x). Use comfyui_list_models with "
+            f"folder='upscale_models' to see available upscalers."
+        )
+
+    prompt_fns["upscale_prompt"] = upscale_prompt
+
+    return prompt_fns

--- a/src/comfyui_mcp/resources.py
+++ b/src/comfyui_mcp/resources.py
@@ -1,0 +1,145 @@
+"""MCP resources: read-only ComfyUI state the LLM can browse without a tool call.
+
+Resources complement the discovery tools — they let a client poll state by URI
+instead of issuing a tool call. Templated resources (e.g. comfyui://models/{folder})
+inherit FastMCP 4's built-in path-traversal screening, on by default.
+
+Per architecture.md "Resources and prompts": resources are read-only. Mutating
+operations stay as tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+
+
+def _json_str(payload: dict[str, Any]) -> str:
+    """Serialize a dict to a JSON string for resource return."""
+    return json.dumps(payload, default=str)
+
+
+def register_resources(
+    mcp: FastMCP,
+    client: ComfyUIClient,
+    audit: AuditLogger,
+    limiter: RateLimiter,
+    sanitizer: PathSanitizer,
+) -> dict[str, Any]:
+    """Register read-only ComfyUI state resources.
+
+    Returns a dict mapping resource keys to the underlying async functions so
+    tests can call them directly (mirrors the register_*_tools() contract).
+    """
+    resource_fns: dict[str, Any] = {}
+
+    @mcp.resource(
+        "comfyui://models/{folder}",
+        name="ComfyUI Models",
+        description="List models in a ComfyUI folder (checkpoints, loras, vae, etc.).",
+        mime_type="application/json",
+    )
+    async def comfyui_models_folder(folder: str) -> str:
+        """List models in a folder. Path-traversal in {folder} is screened by FastMCP."""
+        limiter.check("resource_models")
+        sanitizer.validate_path_segment(folder, label="folder")
+        await audit.async_log(tool="resource_models", action="called", extra={"folder": folder})
+        models = await client.get_models(folder)
+        return _json_str({"folder": folder, "models": models, "count": len(models)})
+
+    resource_fns["comfyui_models_folder"] = comfyui_models_folder
+
+    @mcp.resource(
+        "comfyui://nodes/installed",
+        name="ComfyUI Installed Nodes",
+        description="Sorted list of all available ComfyUI node class types.",
+        mime_type="application/json",
+    )
+    async def comfyui_installed_nodes() -> str:
+        """Return a sorted list of available node class types from /object_info."""
+        limiter.check("resource_nodes")
+        await audit.async_log(tool="resource_nodes", action="called")
+        info = await client.get_object_info()
+        nodes = sorted(info.keys())
+        return _json_str({"nodes": nodes, "count": len(nodes)})
+
+    resource_fns["comfyui_installed_nodes"] = comfyui_installed_nodes
+
+    @mcp.resource(
+        "comfyui://queue",
+        name="ComfyUI Queue",
+        description="Current queue state: running and pending job counts.",
+        mime_type="application/json",
+    )
+    async def comfyui_queue_state() -> str:
+        """Return current queue running/pending counts from /queue."""
+        limiter.check("resource_queue")
+        await audit.async_log(tool="resource_queue", action="called")
+        raw = await client.get_queue()
+        running = len(raw.get("queue_running", []))
+        pending = len(raw.get("queue_pending", []))
+        return _json_str({"running": running, "pending": pending})
+
+    resource_fns["comfyui_queue_state"] = comfyui_queue_state
+
+    @mcp.resource(
+        "comfyui://system",
+        name="ComfyUI System Info",
+        description="Whitelisted system info: ComfyUI version, GPU VRAM, queue counts.",
+        mime_type="application/json",
+    )
+    async def comfyui_system_info() -> str:
+        """Return whitelisted system info (GPU VRAM, queue counts, version only).
+
+        Mirrors the comfyui_get_system_info tool whitelist — sensitive fields
+        (hostname, OS, CPU, paths, Python version, network) are excluded.
+        """
+        limiter.check("resource_system")
+        await audit.async_log(tool="resource_system", action="called")
+
+        raw, queue_raw = await asyncio.gather(
+            client.get_system_stats(),
+            client.get_queue(),
+        )
+
+        devices: list[dict[str, Any]] = []
+        for device in raw.get("devices", []):
+            if not isinstance(device, dict):
+                continue
+            entry: dict[str, Any] = {}
+            if "name" in device:
+                entry["name"] = str(device["name"])
+            vram_total = device.get("vram_total")
+            vram_free = device.get("vram_free")
+            if isinstance(vram_total, int | float):
+                entry["vram_total_mb"] = round(vram_total / (1024 * 1024))
+            if isinstance(vram_free, int | float):
+                entry["vram_free_mb"] = round(vram_free / (1024 * 1024))
+            if "torch_vram_total" in device and isinstance(device["torch_vram_total"], int | float):
+                entry["torch_vram_total_mb"] = round(device["torch_vram_total"] / (1024 * 1024))
+            if "torch_vram_free" in device and isinstance(device["torch_vram_free"], int | float):
+                entry["torch_vram_free_mb"] = round(device["torch_vram_free"] / (1024 * 1024))
+            if entry:
+                devices.append(entry)
+
+        running = len(queue_raw.get("queue_running", []))
+        pending = len(queue_raw.get("queue_pending", []))
+
+        result: dict[str, Any] = {
+            "comfyui_version": str(raw.get("system", {}).get("comfyui_version", "unknown")),
+            "devices": devices,
+            "queue": {"running": running, "pending": pending},
+        }
+        return _json_str(result)
+
+    resource_fns["comfyui_system_info"] = comfyui_system_info
+
+    return resource_fns

--- a/src/comfyui_mcp/server.py
+++ b/src/comfyui_mcp/server.py
@@ -15,6 +15,8 @@ from comfyui_mcp.config import ModelSearchSettings, Settings, load_settings
 from comfyui_mcp.model_manager import ModelManagerDetector
 from comfyui_mcp.node_manager import ComfyUIManagerDetector
 from comfyui_mcp.progress import WebSocketProgress
+from comfyui_mcp.prompts import register_prompts
+from comfyui_mcp.resources import register_resources
 from comfyui_mcp.security.download_validator import DownloadValidator
 from comfyui_mcp.security.inspector import WorkflowInspector
 from comfyui_mcp.security.model_checker import ModelChecker
@@ -157,6 +159,11 @@ def _register_all_tools(
         node_manager=node_manager,
         node_auditor=node_auditor,
     )
+    # Resources and prompts use the read-only limiter — they mirror discovery
+    # tools' cross-cutting concerns (rate limit + audit) but expose state as
+    # URIs the LLM can browse without a tool call.
+    register_resources(server, client, audit, rate_limiters["read"], sanitizer)
+    register_prompts(server, client, audit, rate_limiters["read"], sanitizer)
 
 
 def _build_server(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,99 @@
+"""Tests for MCP prompts (workflow template recipes for the LLM)."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.prompts import register_prompts
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+
+_ALLOWED_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp", ".safetensors"]
+
+
+def _components(tmp_path):
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    limiter = RateLimiter(max_per_minute=60)
+    sanitizer = PathSanitizer(allowed_extensions=_ALLOWED_EXTENSIONS)
+    return client, audit, limiter, sanitizer
+
+
+class TestTxt2imgPrompt:
+    async def test_returns_string_mentioning_tool_and_prompt(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["txt2img_prompt"](prompt="a serene mountain lake")
+        assert isinstance(result, str)
+        assert "comfyui_generate_image" in result
+        assert "a serene mountain lake" in result
+
+    async def test_style_default_is_photorealistic(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["txt2img_prompt"](prompt="a cat")
+        assert "photorealistic" in result.lower()
+
+    async def test_style_override_changes_guidance(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["txt2img_prompt"](prompt="a cat", style="anime")
+        assert "anime" in result.lower()
+
+
+class TestImg2imgPrompt:
+    async def test_returns_string_mentioning_transform_and_image(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["img2img_prompt"](image="photo.png", prompt="make it watercolor")
+        assert isinstance(result, str)
+        assert "comfyui_transform_image" in result
+        assert "photo.png" in result
+        assert "make it watercolor" in result
+
+
+class TestInpaintPrompt:
+    async def test_returns_string_mentioning_inpaint_and_mask(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["inpaint_prompt"](
+            image="photo.png", mask="mask.png", prompt="remove the background"
+        )
+        assert isinstance(result, str)
+        assert "comfyui_inpaint_image" in result
+        assert "mask.png" in result
+
+
+class TestUpscalePrompt:
+    async def test_returns_string_mentioning_upscale(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["upscale_prompt"](image="photo.png")
+        assert isinstance(result, str)
+        assert "comfyui_upscale_image" in result
+
+
+class TestRegistration:
+    async def test_register_prompts_returns_callable_dict(self, tmp_path):
+        client, audit, limiter, sanitizer = _components(tmp_path)
+        mcp = FastMCP("test")
+        fns = register_prompts(mcp, client, audit, limiter, sanitizer)
+        assert isinstance(fns, dict)
+        assert "txt2img_prompt" in fns
+        assert "img2img_prompt" in fns
+        assert "inpaint_prompt" in fns
+        assert "upscale_prompt" in fns

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,159 @@
+"""Tests for MCP resources (read-only ComfyUI state browsing)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.resources import register_resources
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer, PathValidationError
+
+_ALLOWED_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp", ".safetensors"]
+
+
+@pytest.fixture
+def components(tmp_path):
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    limiter = RateLimiter(max_per_minute=60)
+    sanitizer = PathSanitizer(allowed_extensions=_ALLOWED_EXTENSIONS)
+    return client, audit, limiter, sanitizer
+
+
+class TestModelsResource:
+    @respx.mock
+    async def test_models_folder_returns_list(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/models/checkpoints").mock(
+            return_value=httpx.Response(200, json=["v1.safetensors", "v2.safetensors"])
+        )
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["comfyui_models_folder"]("checkpoints")
+        assert isinstance(result, str)
+        import json
+
+        data = json.loads(result)
+        assert data["models"] == ["v1.safetensors", "v2.safetensors"]
+        assert data["count"] == 2
+        assert data["folder"] == "checkpoints"
+
+    @respx.mock
+    async def test_models_folder_empty(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/models/loras").mock(return_value=httpx.Response(200, json=[]))
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["comfyui_models_folder"]("loras")
+        import json
+
+        data = json.loads(result)
+        assert data["models"] == []
+        assert data["count"] == 0
+
+    @respx.mock
+    async def test_models_folder_rejects_traversal(self, components):
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+
+        # Path traversal in the folder segment must be rejected before the
+        # handler runs (FastMCP 4 screens templated resource params by default).
+        with pytest.raises(PathValidationError):
+            await fns["comfyui_models_folder"]("../etc/passwd")
+
+
+class TestNodesResource:
+    @respx.mock
+    async def test_installed_nodes_returns_sorted_list(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/object_info").mock(
+            return_value=httpx.Response(200, json={"KSampler": {}, "CLIPTextEncode": {}})
+        )
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["comfyui_installed_nodes"]()
+        import json
+
+        data = json.loads(result)
+        assert data["nodes"] == ["CLIPTextEncode", "KSampler"]
+        assert data["count"] == 2
+
+
+class TestQueueResource:
+    @respx.mock
+    async def test_queue_returns_running_and_pending(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/queue").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "queue_running": [{"prompt_id": "r1"}],
+                    "queue_pending": [{"prompt_id": "p1"}, {"prompt_id": "p2"}],
+                },
+            )
+        )
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["comfyui_queue_state"]()
+        import json
+
+        data = json.loads(result)
+        assert data["running"] == 1
+        assert data["pending"] == 2
+
+
+class TestSystemResource:
+    @respx.mock
+    async def test_system_returns_whitelisted_fields(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/system_stats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "system": {"comfyui_version": "0.3.0", "hostname": "secret-host"},
+                    "devices": [
+                        {
+                            "name": "cuda:0",
+                            "vram_total": 8589934592,
+                            "vram_free": 4294967296,
+                        }
+                    ],
+                },
+            )
+        )
+        respx.get("http://test:8188/queue").mock(
+            return_value=httpx.Response(200, json={"queue_running": [], "queue_pending": []})
+        )
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+
+        result = await fns["comfyui_system_info"]()
+        import json
+
+        data = json.loads(result)
+        assert data["comfyui_version"] == "0.3.0"
+        assert data["devices"][0]["vram_total_mb"] == 8192
+        assert "hostname" not in data
+        assert "system" not in data
+
+
+class TestRegistration:
+    async def test_register_resources_returns_callable_dict(self, components):
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        fns = register_resources(mcp, client, audit, limiter, sanitizer)
+        assert isinstance(fns, dict)
+        assert "comfyui_models_folder" in fns
+        assert "comfyui_installed_nodes" in fns
+        assert "comfyui_queue_state" in fns
+        assert "comfyui_system_info" in fns


### PR DESCRIPTION
Closes #124. Part of epic #122.

## What

Phase 2 of the FastMCP 4 migration. Ports the godot-mcp resource pattern so the LLM can browse read-only ComfyUI state by URI without a tool call, and exposes the built-in workflow templates as prompt recipes.

### Resources (`src/comfyui_mcp/resources.py`)
| URI | Description |
|-----|-------------|
| `comfyui://models/{folder}` | List models in a folder; templated URI inherits FastMCP 4 built-in path-traversal screening, plus `sanitizer.validate_path_segment` as defense-in-depth |
| `comfyui://nodes/installed` | Sorted node class types from `/object_info` |
| `comfyui://queue` | Running/pending counts from `/queue` |
| `comfyui://system` | Whitelisted system info (version, GPU VRAM, queue counts); mirrors the `comfyui_get_system_info` tool whitelist, excludes hostname/OS/CPU/paths |

### Prompts (`src/comfyui_mcp/prompts.py`)
- `txt2img_prompt`, `img2img_prompt`, `inpaint_prompt`, `upscale_prompt` — return a plain string (auto-wrapped as a user message) per architecture.md; not `mcp.types.PromptMessage` or raw role/content dicts

### Wiring
Both are registered in `server.py` `_register_all_tools()` with the read-only rate limiter and audit logger, mirroring the discovery tools. They **complement** (do not replace) the existing discovery tools — a later phase can deprecate redundant discovery tools if the eval shows the LLM prefers resources.

## Process (red → green)

- **Red**: wrote `tests/test_resources.py` + `tests/test_prompts.py` first; confirmed collection errors (modules did not exist)
- **Green**: implemented `resources.py` + `prompts.py`, wired in `server.py`, all tests pass

## Verification

- [x] `uv run pytest` — **554 passed** (14 new + 540 existing)
- [x] `uv run mypy src/comfyui_mcp/` — clean (32 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pre-commit run --all-files` — green
- [x] README.md — added Resources and Prompts sections to the Tools table

## Notes

- Rule 22 (Phase 4 eval) applies — this adds LLM-facing surface (resources/prompts). Flagging for reviewer judgment on whether to run the eval pre-merge; the surface is additive (no existing tool changed), so regression risk is low. The eval is the signal for whether the LLM ignores resources and still calls `list_models` — if so, the resource text/URIs need adjustment.
- Path-traversal test asserts `PathValidationError` (defense-in-depth at the handler level). FastMCP 4 also screens templated resource params at the framework level before the handler runs.

## Do not

- No middleware, DI, or elicitation in this PR — those are #125, #126, #127.
- No existing discovery tools removed — resources complement them.

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>