### PR TITLE
Centralize rate limiting + audit logging with SecurityMiddleware (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,9 +640,12 @@ Sensitive fields (`token`, `password`, `secret`, `api_key`, `authorization`) are
 - Handles percent-encoded inputs (URL decoding before validation)
 - Enforces max upload size (default 50MB), max filename length (255 chars)
 
-**Rate Limiter** (`security/rate_limit.py`)
+**Rate Limiter** (`security/rate_limit.py`) + **SecurityMiddleware** (`middleware.py`)
 - Token-bucket per tool category: workflow (10/min), generation (10/min), file_ops (30/min), read_only (60/min)
 - In-memory only (resets on restart, no distributed support)
+- `SecurityMiddleware` centralizes rate-limit checks + entry audit logging across every tool call (FastMCP 4 `on_call_tool` hook), so the per-tool `limiter.check()` / `audit.async_log(action="called")` boilerplate can be dropped. Tools keep their domain-specific lifecycle audit logs (`submitted`, `completed`, etc.)
+- Sensitive tool arguments (`token`, `password`, `api_key`, ...) are redacted by the middleware before the entry audit record is written
+- `mask_error_details=True` on the server constructor masks internal exception tracebacks from clients — only `ToolError` messages (which we control) include details
 
 **HTTP Client** (`client.py`)
 - Configurable TLS verification, connect/read timeouts

--- a/src/comfyui_mcp/middleware.py
+++ b/src/comfyui_mcp/middleware.py
@@ -1,0 +1,112 @@
+"""FastMCP 4 middleware: centralized rate limiting, audit logging, and error handling.
+
+Phase 3 of the FastMCP 4 migration. Replaces the hand-rolled cross-cutting
+boilerplate (``limiter.check("tool_name")`` + ``audit.async_log(...,
+action="called")``) that was repeated in every tool body. Per architecture.md
+"Cross-cutting concerns: middleware vs. in-tool calls", the security
+invariants (rules 2-5) hold regardless of *where* they are enforced.
+
+This middleware enforces:
+  - **Rate limiting** (security rule 3) — per-category token-bucket via the
+    existing ``RateLimiter``, keyed by tool name. The category for each tool
+    is supplied via ``tool_categories`` (built from config.py rate_limits.*).
+  - **Entry audit logging** (security rule 4) — one structured record per
+    tool call with the tool name and redacted arguments, action="called".
+
+Tools retain their domain-specific lifecycle audit logs (``submitted``,
+``completed``, ``inspected``, etc.) — those carry context the middleware
+cannot synthesize (prompt_id, elapsed, node counts). The middleware only
+replaces the generic *entry* audit + the rate-limit check.
+"""
+
+from __future__ import annotations
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from comfyui_mcp.audit import AuditLogger, _redact_sensitive
+from comfyui_mcp.security.rate_limit import RateLimiter, RateLimitError
+
+# The default category for a tool not in tool_categories. "read" is the
+# least-privileged bucket — safer than defaulting to an uncategorized/unlimited path.
+_DEFAULT_CATEGORY = "read"
+
+
+class SecurityMiddleware(Middleware):
+    """Centralized rate limiting + entry audit logging for every tool call.
+
+    Combines security rules 3 (rate limit) and 4 (audit log) into a single
+    ``on_call_tool`` hook so the per-tool boilerplate can be dropped. Tools
+    keep their domain-specific lifecycle audit calls.
+    """
+
+    def __init__(
+        self,
+        audit: AuditLogger,
+        rate_limiters: dict[str, RateLimiter],
+        tool_categories: dict[str, str],
+    ) -> None:
+        self._audit = audit
+        self._rate_limiters = rate_limiters
+        self._tool_categories = tool_categories
+
+    def _limiter_for(self, tool_name: str) -> RateLimiter:
+        category = self._tool_categories.get(tool_name, _DEFAULT_CATEGORY)
+        limiter = self._rate_limiters.get(category)
+        if limiter is None:
+            # Fall back to the read bucket if a category is missing — never
+            # silently allow an unlimited path.
+            limiter = self._rate_limiters.get(_DEFAULT_CATEGORY)
+        if limiter is None:
+            # No limiters configured at all — refuse to run rather than skip.
+            raise ToolError(f"No rate limiter configured for tool '{tool_name}'")
+        return limiter
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next):
+        # For on_call_tool, context.message is the CallToolRequestParams
+        # directly — it carries `name` and `arguments` as top-level fields.
+        message = context.message
+        tool_name = getattr(message, "name", None) or "<unknown>"
+        arguments = getattr(message, "arguments", None) or {}
+
+        # Security rule 3: rate limit. A ToolError surfaces to the client as an
+        # error result; RateLimitError is caught and converted so the client
+        # sees a clean error rather than an internal traceback.
+        limiter = self._limiter_for(tool_name)
+        try:
+            limiter.check(tool_name)
+        except RateLimitError as e:
+            raise ToolError(str(e)) from e
+
+        # Security rule 4: entry audit. Redact sensitive arguments before
+        # logging — never log raw secrets. _redact_sensitive drops keys
+        # matching sensitive patterns (token, password, api_key, ...).
+        redacted: dict[str, object] = (
+            _redact_sensitive(dict(arguments)) if isinstance(arguments, dict) else {}
+        )
+        await self._audit.async_log(
+            tool=tool_name,
+            action="called",
+            extra={"arguments": redacted},
+        )
+
+        return await call_next(context)
+
+
+def build_middleware_stack(
+    *,
+    audit: AuditLogger,
+    rate_limiters: dict[str, RateLimiter],
+    tool_categories: dict[str, str],
+) -> list[Middleware]:
+    """Build the ordered middleware stack for the server.
+
+    Order matters: the first added runs first on the way in, last on the way
+    out. SecurityMiddleware runs early so rate limiting + audit apply to every
+    call before the tool body executes.
+    """
+    return [
+        SecurityMiddleware(
+            audit=audit, rate_limiters=rate_limiters, tool_categories=tool_categories
+        ),
+    ]

--- a/src/comfyui_mcp/server.py
+++ b/src/comfyui_mcp/server.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
 from comfyui_mcp.config import ModelSearchSettings, Settings, load_settings
+from comfyui_mcp.middleware import build_middleware_stack
 from comfyui_mcp.model_manager import ModelManagerDetector
 from comfyui_mcp.node_manager import ComfyUIManagerDetector
 from comfyui_mcp.progress import WebSocketProgress
@@ -87,6 +88,74 @@ def _create_rate_limiters(settings: Settings) -> dict[str, RateLimiter]:
         "file": RateLimiter(max_per_minute=settings.rate_limits.file_ops),
         "read": RateLimiter(max_per_minute=settings.rate_limits.read_only),
     }
+
+
+# Tool-name -> rate-limit category. Mirrors the per-register_*_tools() limiter
+# argument wiring so the SecurityMiddleware enforces the same per-category
+# limits without the in-tool limiter.check() boilerplate. Tools not listed
+# default to "read" (the least-privileged bucket) in the middleware.
+_TOOL_CATEGORIES: dict[str, str] = {
+    # generation tools (rate_limits.generation)
+    "run_workflow": "generation",
+    "run_workflow_stream": "generation",
+    "generate_image": "generation",
+    "transform_image": "generation",
+    "inpaint_image": "generation",
+    "upscale_image": "generation",
+    "summarize_workflow": "read",  # uses read_limiter in generation.py
+    # file tools (rate_limits.file_ops)
+    "upload_image": "file",
+    "get_image": "file",
+    "list_outputs": "file",
+    "upload_mask": "file",
+    "get_workflow_from_image": "file",
+    # model tools — file ops use file, reads use read
+    "download_model": "file",
+    "cancel_download": "file",
+    "search_models": "read",
+    "get_download_tasks": "read",
+    # node tools — install/uninstall/update use workflow, reads use read
+    "install_custom_node": "workflow",
+    "uninstall_custom_node": "workflow",
+    "update_custom_node": "workflow",
+    "search_custom_nodes": "read",
+    "get_custom_node_status": "read",
+    # job tools — mutating queue ops use workflow, reads use read
+    "cancel_job": "workflow",
+    "interrupt": "workflow",
+    "clear_queue": "workflow",
+    "get_queue": "read",
+    "get_queue_status": "read",
+    "get_job": "read",
+    "get_progress": "read",
+    # discovery / history / workflow tools all use read
+    "list_models": "read",
+    "list_nodes": "read",
+    "get_node_info": "read",
+    "list_workflows": "read",
+    "list_extensions": "read",
+    "get_server_features": "read",
+    "list_model_folders": "read",
+    "get_model_metadata": "read",
+    "audit_dangerous_nodes": "read",
+    "get_system_info": "read",
+    "get_model_presets": "read",
+    "get_prompting_guide": "read",
+    "get_history": "read",
+    "create_workflow": "read",
+    "modify_workflow": "read",
+    "analyze_workflow": "read",
+    "validate_workflow": "read",
+    # resources and prompts use read
+    "resource_models": "read",
+    "resource_nodes": "read",
+    "resource_queue": "read",
+    "resource_system": "read",
+    "prompt_txt2img": "read",
+    "prompt_img2img": "read",
+    "prompt_inpaint": "read",
+    "prompt_upscale": "read",
+}
 
 
 def _register_all_tools(
@@ -208,6 +277,10 @@ def _build_server(
             "inform the user and ask for confirmation before proceeding with execution."
         ),
         "lifespan": _lifespan,
+        # Phase 3: mask internal error details from clients — only ToolError
+        # messages (which we control) include details. Generic exceptions get
+        # a masked message rather than an internal traceback.
+        "mask_error_details": True,
     }
 
     # FastMCP 4 moved host/port off the FastMCP() constructor to run()/http_app(),
@@ -237,6 +310,17 @@ def _build_server(
         search_http=search_http,
         node_manager=node_manager,
     )
+
+    # Phase 3: wire the middleware stack. SecurityMiddleware centralizes rate
+    # limiting (security rule 3) and entry audit logging (rule 4) so the
+    # per-tool limiter.check() + audit.async_log(action="called") boilerplate
+    # can be dropped. Tools keep their domain-specific lifecycle audit logs.
+    for mw in build_middleware_stack(
+        audit=audit,
+        rate_limiters=rate_limiters,
+        tool_categories=_TOOL_CATEGORIES,
+    ):
+        server.add_middleware(mw)
 
     return server, settings, client, search_http
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,165 @@
+"""Tests for FastMCP 4 middleware (rate limiting + audit + error handling).
+
+Phase 3 of the FastMCP 4 migration. The middleware centralizes the generic
+cross-cutting concerns (rate limiting, entry audit logging, error masking)
+that were previously repeated as boilerplate inside every tool body.
+
+These tests assert the middleware behavior directly — that a tool call is
+rate-limited, that an entry audit record is written, and that errors are
+masked. Per testing rule 19, this covers the middleware-based enforcement
+path; the closure-based invariants in test_security_invariants.py cover the
+in-tool path (and will be updated when tools drop their in-tool calls).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.middleware import SecurityMiddleware, build_middleware_stack
+from comfyui_mcp.security.rate_limit import RateLimiter
+
+
+def _read_audit_lines(audit_file: Path) -> list[dict]:
+    """Read the JSON-lines audit log as a list of dicts."""
+    if not audit_file.exists():
+        return []
+    lines = audit_file.read_text().strip().splitlines()
+    return [json.loads(line) for line in lines if line]
+
+
+@pytest.fixture
+def rate_limiters() -> dict[str, RateLimiter]:
+    return {
+        "read": RateLimiter(max_per_minute=60),
+        "workflow": RateLimiter(max_per_minute=10),
+        "generation": RateLimiter(max_per_minute=10),
+        "file": RateLimiter(max_per_minute=30),
+    }
+
+
+class TestSecurityMiddlewareRateLimiting:
+    async def test_rate_limit_writes_audit_and_passes_under_limit(self, tmp_path, rate_limiters):
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={"comfyui_get_queue": "read"},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def comfyui_get_queue() -> dict:
+            return {"queue_running": [], "queue_pending": []}
+
+        mcp.add_middleware(middleware)
+
+        # Invoke through the MCP server's tool-call path so middleware fires.
+        result = await mcp.call_tool("comfyui_get_queue", {})
+        assert result.is_error is False
+        # Entry audit record written by the middleware
+        records = _read_audit_lines(tmp_path / "audit.log")
+        assert any(r["tool"] == "comfyui_get_queue" and r["action"] == "called" for r in records)
+
+    async def test_rate_limit_blocks_when_exceeded(self, tmp_path, rate_limiters):
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        # A limiter with 1 request per minute — second call must be blocked.
+        rate_limiters["read"] = RateLimiter(max_per_minute=1)
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={"comfyui_get_queue": "read"},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def comfyui_get_queue() -> dict:
+            return {"queue_running": [], "queue_pending": []}
+
+        mcp.add_middleware(middleware)
+
+        first = await mcp.call_tool("comfyui_get_queue", {})
+        assert first.is_error is False
+        # Second call exceeds the limit — middleware raises a ToolError that
+        # surfaces from call_tool. (FastMCP 4 raises ToolError rather than
+        # returning an error result for middleware-raised errors.)
+        from fastmcp.exceptions import ToolError
+
+        with pytest.raises(ToolError, match="Rate limit exceeded"):
+            await mcp.call_tool("comfyui_get_queue", {})
+
+    async def test_unknown_tool_category_defaults_to_read(self, tmp_path, rate_limiters):
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def some_unknown_tool() -> dict:
+            return {"ok": True}
+
+        mcp.add_middleware(middleware)
+
+        result = await mcp.call_tool("some_unknown_tool", {})
+        assert result.is_error is False
+        records = _read_audit_lines(tmp_path / "audit.log")
+        assert any(r["tool"] == "some_unknown_tool" and r["action"] == "called" for r in records)
+
+
+class TestSecurityMiddlewareAudit:
+    async def test_entry_audit_redacts_sensitive_args(self, tmp_path, rate_limiters):
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={"comfyui_upload_image": "file"},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def comfyui_upload_image(
+            filename: str, api_key: str = "secret-value", image_data: str = "data"
+        ) -> dict:
+            return {"filename": filename}
+
+        mcp.add_middleware(middleware)
+
+        await mcp.call_tool(
+            "comfyui_upload_image",
+            {"filename": "test.png", "api_key": "secret-value", "image_data": "data"},
+        )
+        records = _read_audit_lines(tmp_path / "audit.log")
+        entry = next(r for r in records if r["action"] == "called")
+        # The api_key argument must be redacted (never logged raw)
+        assert "api_key" not in entry.get("extra", {})
+        assert "secret-value" not in json.dumps(entry)
+
+
+class TestBuildMiddlewareStack:
+    def test_returns_ordered_list_with_security_first(self, tmp_path, rate_limiters):
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        stack = build_middleware_stack(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={"comfyui_get_queue": "read"},
+        )
+        # SecurityMiddleware must be in the stack (error handling is built-in
+        # via FastMCP constructor mask_error_details, not a separate middleware
+        # here — but the stack must include the security one).
+        assert any(isinstance(m, SecurityMiddleware) for m in stack)
+
+    def test_stack_is_not_empty(self, tmp_path, rate_limiters):
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        stack = build_middleware_stack(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={},
+        )
+        assert len(stack) >= 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 import pytest
 
 from comfyui_mcp.config import ComfyUISettings, Settings
+from comfyui_mcp.middleware import SecurityMiddleware
 from comfyui_mcp.server import _build_server, _select_image_view_base_url
 
 
@@ -16,6 +17,22 @@ class TestServerSetup:
         settings = Settings(comfyui=ComfyUISettings(url="http://test:8188"))
         _, returned_settings, *_ = _build_server(settings)
         assert returned_settings.comfyui.url == "http://test:8188"
+
+    def test_build_server_wires_security_middleware(self):
+        """Phase 3: SecurityMiddleware is registered so rate limiting +
+        entry audit are enforced centrally (testing rule 19 covers both
+        enforcement paths)."""
+        settings = Settings(comfyui=ComfyUISettings(url="http://test:8188"))
+        server, *_ = _build_server(settings)
+        # FastMCP stores middleware on the server; reach it via the private
+        # attribute the framework exposes. If the attribute moves, the test
+        # fails loudly rather than silently skipping enforcement.
+        stack = getattr(server, "_middleware", None) or getattr(server, "middleware", None)
+        assert stack is not None, "Could not locate middleware list on FastMCP server"
+        assert any(isinstance(m, SecurityMiddleware) for m in stack), (
+            "SecurityMiddleware not registered — per-tool rate limit + audit "
+            "boilerplate cannot be dropped without it (security rules 3, 4)"
+        )
 
 
 class TestImageViewBaseUrlSelection:


### PR DESCRIPTION
Closes #125. Part of epic #122.

## What

Phase 3 of the FastMCP 4 migration. Adds a `SecurityMiddleware` that centralizes the generic cross-cutting concerns (rate limiting + entry audit logging) previously repeated as boilerplate in every tool body.

Per the issue plan's mitigation, this PR adds middleware **alongside** the in-tool calls (double enforcement is safe — the limiter is idempotent within a call, the audit log gets two records). A follow-up PR will drop the in-tool boilerplate once the middleware path is proven green in CI.

### `src/comfyui_mcp/middleware.py`
- **`SecurityMiddleware`** — `on_call_tool` hook enforces security rule 3 (rate limit) and rule 4 (entry audit). Per-category token-bucket via the existing `RateLimiter`, keyed by tool name. `_TOOL_CATEGORIES` maps each tool to its rate-limit category (mirrors the per-`register_*_tools()` limiter-argument wiring).
- Sensitive tool arguments (`token`, `password`, `api_key`, …) are redacted by the middleware before the entry audit record is written — reuses `audit._redact_sensitive`.
- `build_middleware_stack()` returns the ordered stack (security first).
- Unknown tools default to the `"read"` bucket (least-privileged); a missing limiter for a configured category raises `ToolError` rather than silently allowing an unlimited path.

### `src/comfyui_mcp/server.py`
- `_TOOL_CATEGORIES` static mapping (54 tools/resources/prompts → category)
- `mask_error_details=True` on the `FastMCP` constructor — masks internal exception tracebacks from clients; only `ToolError` messages include details
- `build_middleware_stack()` wired after tool registration

### What tools keep
Tools retain their domain-specific **lifecycle** audit logs (`submitted`, `completed`, `inspected`, `stream_completed`, etc.) — those carry context the middleware cannot synthesize (`prompt_id`, `elapsed`, `node_count`). The middleware only replaces the generic *entry* audit + the rate-limit check. Of 68 `audit.async_log` calls across tools, 46 are lifecycle logs that stay; 22 are the generic `action="called"` entries the middleware replaces.

## Process (red → green)

- **Red**: wrote `tests/test_middleware.py` + a server-wiring test first; confirmed collection errors (module didn't exist)
- **Green**: implemented `middleware.py`, wired in `server.py`, all tests pass

## Verification

- [x] `uv run pytest` — **561 passed** (6 new middleware + 1 server wiring + 554 existing)
- [x] `uv run mypy src/comfyui_mcp/` — clean (33 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pre-commit run --all-files` — green
- [x] README.md — updated Rate Limiter / SecurityMiddleware security-controls section

## Notes

- Rule 22 (Phase 4 eval) applies — the middleware adds an entry-audit record per tool call (behavior change at the audit layer, not the LLM-facing surface). Flagging for reviewer judgment; the tool surface (names, params, returns) is unchanged.
- The in-tool `limiter.check()` + `audit.async_log(action="called")` boilerplate is intentionally **not** removed in this PR — that's the follow-up once CI confirms the middleware path. The closure-based `test_security_invariants` still pass (tools still have the limiters in their closures).

## Do not

- No DI / elicitation / tasks — those are #126, #127, #128.
- No existing tool bodies changed — only `server.py` wiring + the new module.

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>