### PR TITLE
Add Depends() DI infrastructure + history_di proof module (#126)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,11 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S106"]         # allow assert, hardcoded passwords in tests
 "scripts/*" = ["T201"]               # CLI scripts use print intentionally
+# DI tool files use Depends() / Progress() in argument defaults — the
+# documented FastMCP 4 / FastAPI idiom for dependency injection. B008
+# (function call in default) is a false positive on this pattern.
+"src/comfyui_mcp/tools/*_di.py" = ["B008"]
+"src/comfyui_mcp/dependencies.py" = ["B008"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/comfyui_mcp/dependencies.py
+++ b/src/comfyui_mcp/dependencies.py
@@ -1,0 +1,142 @@
+"""Dependency-injection providers for FastMCP 4 Depends().
+
+Phase 4 of the FastMCP 4 migration. Lets tools declare their dependencies as
+``Depends(get_client)`` parameters (auto-excluded from the MCP schema) instead
+of receiving them as positional args through register_*_tools() factories.
+
+The providers resolve the module-level singletons built by ``_build_server()``
+in ``server.py``. They are set once at startup via ``configure_dependencies()``
+so each provider returns the live instance. Tests can re-configure with test
+doubles.
+
+This is opt-in per-tool-module: a tool module may keep its register_*_tools()
+factory OR define module-level decorated functions using these providers.
+Both patterns are valid per architecture.md rule 11.
+"""
+
+from __future__ import annotations
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.security.inspector import WorkflowInspector
+from comfyui_mcp.security.model_checker import ModelChecker
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+
+# Module-level singleton slots. Populated by configure_dependencies() at
+# server startup (server.py:_build_server) and by tests with their own
+# instances. A provider raises if called before configuration — fail loud
+# rather than silently returning None.
+_client: ComfyUIClient | None = None
+_audit: AuditLogger | None = None
+_inspector: WorkflowInspector | None = None
+_sanitizer: PathSanitizer | None = None
+_model_checker: ModelChecker | None = None
+_read_limiter: RateLimiter | None = None
+_workflow_limiter: RateLimiter | None = None
+_generation_limiter: RateLimiter | None = None
+_file_limiter: RateLimiter | None = None
+
+
+def configure_dependencies(
+    *,
+    client: ComfyUIClient,
+    audit: AuditLogger,
+    inspector: WorkflowInspector,
+    sanitizer: PathSanitizer,
+    model_checker: ModelChecker,
+    read_limiter: RateLimiter,
+    workflow_limiter: RateLimiter,
+    generation_limiter: RateLimiter,
+    file_limiter: RateLimiter,
+) -> None:
+    """Populate the module-level singleton slots. Called once at startup."""
+    global _client, _audit, _inspector, _sanitizer, _model_checker
+    global _read_limiter, _workflow_limiter, _generation_limiter, _file_limiter
+    _client = client
+    _audit = audit
+    _inspector = inspector
+    _sanitizer = sanitizer
+    _model_checker = model_checker
+    _read_limiter = read_limiter
+    _workflow_limiter = workflow_limiter
+    _generation_limiter = generation_limiter
+    _file_limiter = file_limiter
+
+
+def reset_dependencies() -> None:
+    """Clear the singleton slots. For test isolation between modules."""
+    global _client, _audit, _inspector, _sanitizer, _model_checker
+    global _read_limiter, _workflow_limiter, _generation_limiter, _file_limiter
+    _client = None
+    _audit = None
+    _inspector = None
+    _sanitizer = None
+    _model_checker = None
+    _read_limiter = None
+    _workflow_limiter = None
+    _generation_limiter = None
+    _file_limiter = None
+
+
+def get_client() -> ComfyUIClient:
+    """Resolve the ComfyUI HTTP client singleton."""
+    if _client is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _client
+
+
+def get_audit() -> AuditLogger:
+    """Resolve the audit logger singleton."""
+    if _audit is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _audit
+
+
+def get_inspector() -> WorkflowInspector:
+    """Resolve the workflow inspector singleton."""
+    if _inspector is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _inspector
+
+
+def get_sanitizer() -> PathSanitizer:
+    """Resolve the path sanitizer singleton."""
+    if _sanitizer is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _sanitizer
+
+
+def get_model_checker() -> ModelChecker:
+    """Resolve the model checker singleton."""
+    if _model_checker is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _model_checker
+
+
+def get_read_limiter() -> RateLimiter:
+    """Resolve the read-only rate limiter singleton."""
+    if _read_limiter is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _read_limiter
+
+
+def get_workflow_limiter() -> RateLimiter:
+    """Resolve the workflow rate limiter singleton."""
+    if _workflow_limiter is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _workflow_limiter
+
+
+def get_generation_limiter() -> RateLimiter:
+    """Resolve the generation rate limiter singleton."""
+    if _generation_limiter is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _generation_limiter
+
+
+def get_file_limiter() -> RateLimiter:
+    """Resolve the file-ops rate limiter singleton."""
+    if _file_limiter is None:
+        raise RuntimeError("Dependencies not configured — call configure_dependencies() first")
+    return _file_limiter

--- a/src/comfyui_mcp/server.py
+++ b/src/comfyui_mcp/server.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
 from comfyui_mcp.config import ModelSearchSettings, Settings, load_settings
+from comfyui_mcp.dependencies import configure_dependencies
 from comfyui_mcp.middleware import build_middleware_stack
 from comfyui_mcp.model_manager import ModelManagerDetector
 from comfyui_mcp.node_manager import ComfyUIManagerDetector
@@ -24,10 +25,10 @@ from comfyui_mcp.security.model_checker import ModelChecker
 from comfyui_mcp.security.node_auditor import NodeAuditor
 from comfyui_mcp.security.rate_limit import RateLimiter
 from comfyui_mcp.security.sanitizer import PathSanitizer
+from comfyui_mcp.tools import history_di
 from comfyui_mcp.tools.discovery import register_discovery_tools
 from comfyui_mcp.tools.files import register_file_tools
 from comfyui_mcp.tools.generation import register_generation_tools
-from comfyui_mcp.tools.history import register_history_tools
 from comfyui_mcp.tools.jobs import register_job_tools
 from comfyui_mcp.tools.models import register_model_tools
 from comfyui_mcp.tools.nodes import register_node_tools
@@ -178,7 +179,10 @@ def _register_all_tools(
 ) -> None:
     """Register all MCP tool groups with their dependencies."""
     register_discovery_tools(server, client, audit, rate_limiters["read"], sanitizer, node_auditor)
-    register_history_tools(server, client, audit, rate_limiters["read"])
+    # Phase 4: history tool uses the DI version (module-level decorated fn
+    # with Depends()). The factory version stays for test_security_invariants
+    # closure checks until the full migration lands.
+    history_di.register(server)
     register_job_tools(
         server,
         client,
@@ -264,6 +268,22 @@ def _build_server(
     )
     model_checker = ModelChecker()
     search_http = httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=30, write=10, pool=10))
+
+    # Phase 4: populate the DI provider slots so module-level decorated tools
+    # (history_di, and future DI migrations) can resolve their dependencies via
+    # Depends(). The factory-based tools still receive the same singletons
+    # positionally through register_*_tools() — both patterns coexist.
+    configure_dependencies(
+        client=client,
+        audit=audit,
+        inspector=inspector,
+        sanitizer=sanitizer,
+        model_checker=model_checker,
+        read_limiter=rate_limiters["read"],
+        workflow_limiter=rate_limiters["workflow"],
+        generation_limiter=rate_limiters["generation"],
+        file_limiter=rate_limiters["file"],
+    )
 
     server_kwargs: dict = {
         "name": "ComfyUI",

--- a/src/comfyui_mcp/tools/history_di.py
+++ b/src/comfyui_mcp/tools/history_di.py
@@ -1,0 +1,105 @@
+"""History tool (DI version) — module-level decorated function using Depends().
+
+Phase 4 of the FastMCP 4 migration. Proof module: demonstrates the
+module-level decorated-function pattern with Depends() for dependency
+injection, replacing the register_history_tools() factory.
+
+Per architecture.md rule 11, both patterns are valid. This module is opt-in:
+server.py registers it via register() instead of the factory. The tool
+surface (name, params, returns) is identical to the factory version.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.dependencies import Depends
+from mcp.types import ToolAnnotations
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.dependencies import get_audit, get_client, get_read_limiter
+from comfyui_mcp.pagination import LimitField, OffsetField
+from comfyui_mcp.security.rate_limit import RateLimiter
+
+
+async def _get_history_impl(
+    limit: int,
+    offset: int,
+    client: ComfyUIClient,
+    audit: AuditLogger,
+    limiter: RateLimiter,
+) -> dict[str, Any]:
+    """Shared implementation — callable directly with explicit deps (tests)
+    or via Depends() resolution (framework). Kept separate so tests can call
+    it without going through the MCP framework if needed."""
+    limiter.check("get_history")
+    await audit.async_log(
+        tool="get_history", action="called", extra={"limit": limit, "offset": offset}
+    )
+
+    # Fetch one extra entry so we can detect has_more without a second call.
+    get_history_kwargs: dict[str, Any] = {"max_items": limit + 1}
+    if offset > 0:
+        get_history_kwargs["offset"] = offset
+    raw = await client.get_history(**get_history_kwargs)
+
+    entries = [{**(v if isinstance(v, dict) else {}), "prompt_id": k} for k, v in raw.items()]
+
+    has_more = len(entries) > limit
+    page = entries[:limit]
+    count = len(page)
+    total: int | None
+    if has_more or (count == 0 and offset > 0):  # noqa: SIM108
+        total = None
+    else:
+        total = offset + count
+
+    return {
+        "items": page,
+        "count": count,
+        "offset": offset,
+        "limit": limit,
+        "has_more": has_more,
+        "total": total,
+    }
+
+
+def register(mcp: FastMCP) -> None:
+    """Register the DI-based history tool on a FastMCP server.
+
+    Mirrors the register_*_tools() contract but takes no dependencies — they
+    are resolved via Depends() at call time. server.py calls this once.
+    """
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=True,
+        )
+    )
+    async def comfyui_get_history(
+        limit: LimitField = 25,
+        offset: OffsetField = 0,
+        client: ComfyUIClient = Depends(get_client),
+        audit: AuditLogger = Depends(get_audit),
+        limiter: RateLimiter = Depends(get_read_limiter),
+    ) -> dict[str, Any]:
+        """Browse ComfyUI execution history (read-only).
+
+        Uses server-side ``/history?offset=N&max_items=M`` so callers can page
+        arbitrarily far back. The tool requests one extra entry per page so it
+        can set ``has_more`` without an additional round-trip.
+
+        Args:
+            limit: Maximum number of results to return (default: 25, max: 100)
+            offset: Zero-based starting index (default: 0)
+
+        Returns:
+            Envelope with keys ``items``, ``count`` (items in this page),
+            ``offset``, ``limit``, ``has_more``, and ``total``.
+        """
+        return await _get_history_impl(limit, offset, client, audit, limiter)

--- a/tests/test_tools_history_di.py
+++ b/tests/test_tools_history_di.py
@@ -1,0 +1,99 @@
+"""Tests for the DI-based history tool (Depends() proof module, Phase 4).
+
+Verifies the module-level decorated tool resolves its dependencies
+(client, audit, limiter) via Depends() when called through the MCP
+framework, and that the tool surface (name, params, returns) is unchanged
+from the factory version.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.dependencies import configure_dependencies, reset_dependencies
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.tools import history_di
+
+
+@pytest.fixture
+def configured(tmp_path):
+    """Wire dependencies with test doubles."""
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    read_limiter = RateLimiter(max_per_minute=60)
+    workflow_limiter = RateLimiter(max_per_minute=10)
+    generation_limiter = RateLimiter(max_per_minute=10)
+    file_limiter = RateLimiter(max_per_minute=30)
+    from comfyui_mcp.security.inspector import WorkflowInspector
+    from comfyui_mcp.security.model_checker import ModelChecker
+    from comfyui_mcp.security.sanitizer import PathSanitizer
+
+    configure_dependencies(
+        client=client,
+        audit=audit,
+        inspector=WorkflowInspector(mode="audit", dangerous_nodes=[], allowed_nodes=[]),
+        sanitizer=PathSanitizer(allowed_extensions=[".png"]),
+        model_checker=ModelChecker(),
+        read_limiter=read_limiter,
+        workflow_limiter=workflow_limiter,
+        generation_limiter=generation_limiter,
+        file_limiter=file_limiter,
+    )
+    yield client
+    reset_dependencies()
+
+
+class TestGetHistoryDI:
+    @respx.mock
+    async def test_resolves_dependencies_via_depends(self, configured):
+        """The module-level tool resolves client/audit/limiter via Depends()
+        when called through mcp.call_tool() — no factory needed."""
+        respx.get("http://test:8188/history").mock(
+            return_value=httpx.Response(200, json={"abc": {"outputs": {}}})
+        )
+        mcp = FastMCP("test")
+        history_di.register(mcp)
+        result = await mcp.call_tool("comfyui_get_history", {"limit": 25, "offset": 0})
+        assert result.is_error is False
+        assert result.structured_content["count"] == 1
+        assert result.structured_content["total"] == 1
+
+    @respx.mock
+    async def test_surface_unchanged_returns_envelope(self, configured):
+        """The tool's return shape is identical to the factory version."""
+        respx.get("http://test:8188/history").mock(
+            return_value=httpx.Response(200, json={"abc": {"outputs": {}}, "def": {"outputs": {}}})
+        )
+        mcp = FastMCP("test")
+        history_di.register(mcp)
+        result = await mcp.call_tool("comfyui_get_history", {"limit": 25})
+        sc = result.structured_content
+        assert set(sc.keys()) == {"items", "count", "offset", "limit", "has_more", "total"}
+        assert sc["count"] == 2
+        assert sc["has_more"] is False
+
+    @respx.mock
+    async def test_schema_excludes_dependencies(self, configured):
+        """Depends() params (client, audit, limiter) must NOT appear in the
+        tool's input schema — only limit and offset."""
+        mcp = FastMCP("test")
+        history_di.register(mcp)
+        tools = await mcp.list_tools()
+        tool = next(t for t in tools if t.name == "comfyui_get_history")
+        schema_props = set(tool.parameters.get("properties", {}).keys())
+        assert schema_props == {"limit", "offset"}
+
+
+class TestProviderMisconfiguration:
+    async def test_provider_raises_when_unconfigured(self, tmp_path):
+        """A provider called before configure_dependencies() fails loud."""
+        reset_dependencies()
+        from comfyui_mcp.dependencies import get_client
+
+        with pytest.raises(RuntimeError, match="Dependencies not configured"):
+            get_client()


### PR DESCRIPTION
Closes #126 (infrastructure + proof module). Part of epic #122.

## What

Phase 4 of the FastMCP 4 migration. Adds the dependency-injection infrastructure and converts `history.py` as the proof module. The remaining 7 tool modules migrate incrementally on top of this proven pattern — one module per commit, so a revert is granular.

Per architecture.md rule 11, **both** the `register_*_tools()` factory and the module-level `Depends()`-decorated patterns are valid. This PR adds the second option; it does **not** remove the factory.

### `src/comfyui_mcp/dependencies.py`
- `configure_dependencies()` / `reset_dependencies()` populate module-level singleton slots at server startup (called in `_build_server`)
- Providers `get_client`, `get_audit`, `get_inspector`, `get_sanitizer`, `get_model_checker`, `get_{read,workflow,generation,file}_limiter` resolve the singletons for `Depends()` injection. A provider raises loud (`RuntimeError`) if called before configuration rather than returning `None`.

### `src/comfyui_mcp/tools/history_di.py`
- Module-level decorated `comfyui_get_history` using `Depends(get_client/get_audit/get_read_limiter)`. The tool surface (name, params, returns) is identical to the factory version.
- `_get_history_impl` is the shared async body — callable with explicit deps (tests) or via `Depends()` resolution (framework).
- `register(mcp)` replaces the factory's `register_history_tools(mcp, ...)` — no positional dependencies to pass.

### `server.py`
- `configure_dependencies()` wired in `_build_server()` after the singletons are created
- `_register_all_tools()` calls `history_di.register(server)` instead of `register_history_tools(...)`. The factory function stays importable for `test_security_invariants` closure checks until the full migration lands.

### `pyproject.toml`
- `B008` per-file-ignore for `*_di.py` and `dependencies.py` — `Depends()` in argument defaults is the documented FastMCP 4 idiom (same as FastAPI); `B008` is a false positive on this pattern.

## Process (red → green)

- **Red**: wrote `tests/test_tools_history_di.py` first; confirmed import error (module didn't exist)
- **Green**: implemented `dependencies.py` + `history_di.py`, wired in `server.py`, all tests pass

## Verification

- [x] `uv run pytest` — **565 passed** (4 new + 561 existing)
- [x] `uv run mypy src/comfyui_mcp/` — clean (35 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pre-commit run --all-files` — green
- [x] The existing `tests/test_tools_history.py` (factory version) still pass — the factory function is not removed.

## Scope note (why not all 8 modules in this PR)

Converting all 8 tool modules + ~30 test files + resources + prompts + the invariants fixture in one PR would be a massive review burden with high regression risk. This PR proves the pattern end-to-end (providers, module-level tool, wiring, schema exclusion, test invocation). The remaining modules migrate incrementally — each becomes a `*_di.py` module + `register()` swap, one per commit. This matches the issue plan's explicit guidance: *"Mitigate by migrating one tool module per commit so a revert is granular."*

## Notes

- Rule 22 (Phase 4 eval) applies in principle, but the tool surface is **unchanged** — `comfyui_get_history` keeps the same name, params, and return shape. The DI wiring is internal. The new DI tests verify the schema excludes the dependency params (`limit`, `offset` only).
- Phase 5 (elicitation, #127) can use `Context` injection via this same `Depends` mechanism in either factory or DI tools — it does not require the remaining modules to convert first.

## Do not

- No elicitation / tasks — those are #127, #128.
- No existing factory removed — `register_history_tools` still importable.

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>