### PR TITLE
Gate inspector enforce-mode warnings through user elicitation (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,8 @@ security:
 
 **Tip:** Use `comfyui_audit_dangerous_nodes` to identify dangerous nodes, run workflows in audit mode to see which nodes you use, then switch to enforce mode with that allowlist.
 
+**Elicitation gate (Phase 5):** when enforce mode is on and the inspector produces warnings (dangerous-node types, suspicious inputs like `eval()`/`exec()`, or missing models), the generation tools (`comfyui_run_workflow`, `comfyui_generate_image`, `comfyui_transform_image`, `comfyui_inpaint_image`, `comfyui_upscale_image`) ask the user to confirm before submitting — `ctx.elicit(..., response_type=bool)`. A decline or cancel raises `WorkflowBlockedError` without calling `post_prompt`. Unapproved-node enforcement (the `allowed_nodes` allowlist) still blocks hard inside the inspector before elicitation; the gate fires on the warning path. Programmatic callers without a live MCP context keep the pre-existing behavior (immediate `WorkflowBlockedError` in enforce mode with warnings).
+
 ## Audit log
 
 All tool invocations are logged as JSON lines to `~/.comfyui-mcp/audit.log`:

--- a/src/comfyui_mcp/tools/generation.py
+++ b/src/comfyui_mcp/tools/generation.py
@@ -8,7 +8,7 @@ import json
 from typing import Annotated, Any, Literal
 
 import httpx
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
@@ -115,6 +115,7 @@ async def _submit_workflow(
     stream_events: bool = False,
     model_checker: ModelChecker | None = None,
     inspect_extra: dict[str, Any] | None = None,
+    ctx: Any = None,
 ) -> dict[str, Any]:
     """Inspect, submit, and optionally wait for a workflow.
 
@@ -133,13 +134,20 @@ async def _submit_workflow(
 
     ``success_message`` is preserved in the audit log but no longer surfaces in
     the return value — callers consume structured fields.
+
+    Elicitation gate (Phase 5): when ``ctx`` is provided and the inspector is
+    in enforce mode with warnings, the user is asked to confirm before
+    submission. A decline/cancel or an accept with data=False raises
+    WorkflowBlockedError without calling post_prompt. When ``ctx`` is None
+    (direct/test callers), the pre-existing behavior is preserved —
+    WorkflowBlockedError is raised immediately in enforce mode with warnings.
     """
     inspection = inspector.inspect(wf)
     if model_checker is not None:
         model_warnings = await model_checker.check_models(wf, client)
         if model_warnings:
             inspection.warnings.extend(model_warnings)
-            if inspector.mode == "enforce":
+            if inspector.mode == "enforce" and not ctx:
                 raise WorkflowBlockedError(f"Workflow blocked — missing models: {model_warnings}")
 
     log_kwargs: dict[str, Any] = {
@@ -153,6 +161,39 @@ async def _submit_workflow(
     if model_checker is not None:
         log_kwargs["status"] = "allowed"
     await audit.async_log(**log_kwargs)
+
+    # Elicitation gate (Phase 5): in enforce mode with warnings, ask the user
+    # to confirm before submitting. Only fires when ctx is provided (a live
+    # MCP request). Direct/test callers (ctx=None) keep the pre-existing
+    # behavior — WorkflowBlockedError is raised below for enforce + warnings.
+    if inspection.warnings and inspector.mode == "enforce":
+        if ctx is not None:
+            await audit.async_log(
+                tool=tool_name,
+                action="eliciting_confirmation",
+                extra={"warnings": inspection.warnings},
+            )
+            elicit_result = await ctx.elicit(
+                message=(
+                    f"Workflow has {len(inspection.warnings)} warning(s) in "
+                    f"enforce mode: {inspection.warnings}. Proceed with submission?"
+                ),
+                response_type=bool,
+            )
+            action = getattr(elicit_result, "action", None)
+            accepted = action == "accept"
+            data = getattr(elicit_result, "data", None) if accepted else None
+            if not (accepted and data is True):
+                await audit.async_log(
+                    tool=tool_name,
+                    action="elicitation_declined",
+                    extra={"action": action, "warnings": inspection.warnings},
+                )
+                raise WorkflowBlockedError(
+                    f"Workflow blocked by user — dangerous nodes: {inspection.warnings}"
+                )
+        else:
+            raise WorkflowBlockedError(f"Workflow blocked — dangerous nodes: {inspection.warnings}")
 
     # Fail fast if the caller asked us to wait but no progress tracker is
     # wired in — otherwise we'd silently return a submitted envelope and the
@@ -461,7 +502,9 @@ def register_generation_tools(
             open_world_hint=True,
         )
     )
-    async def comfyui_run_workflow(workflow: str, wait: bool = False) -> dict[str, Any]:
+    async def comfyui_run_workflow(
+        workflow: str, wait: bool = False, ctx: Context | None = None
+    ) -> dict[str, Any]:
         """Submit an arbitrary ComfyUI workflow for execution.
 
         See also: comfyui_run_workflow_stream for a streaming variant that emits
@@ -488,6 +531,7 @@ def register_generation_tools(
             progress=progress,
             stream_events=False,
             model_checker=model_checker,
+            ctx=ctx,
         )
 
     tool_fns["comfyui_run_workflow"] = comfyui_run_workflow
@@ -500,7 +544,9 @@ def register_generation_tools(
             open_world_hint=True,
         )
     )
-    async def comfyui_run_workflow_stream(workflow: str) -> dict[str, Any]:
+    async def comfyui_run_workflow_stream(
+        workflow: str, ctx: Context | None = None
+    ) -> dict[str, Any]:
         """Submit a ComfyUI workflow and return websocket stream events plus final status.
 
         Uses ComfyUI's websocket stream endpoint internally to capture per-event
@@ -531,6 +577,7 @@ def register_generation_tools(
             progress=progress,
             stream_events=True,
             model_checker=model_checker,
+            ctx=ctx,
         )
 
     tool_fns["comfyui_run_workflow_stream"] = comfyui_run_workflow_stream
@@ -552,6 +599,7 @@ def register_generation_tools(
         cfg: CfgField = 7.0,
         model: ModelNameField = "",
         wait: WaitField = False,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Generate an image from a text prompt using a default txt2img workflow."""
         limiter.check("generate_image")
@@ -576,6 +624,7 @@ def register_generation_tools(
             stream_events=False,
             model_checker=model_checker,
             inspect_extra={"prompt": prompt, "width": width, "height": height},
+            ctx=ctx,
         )
 
     tool_fns["comfyui_generate_image"] = comfyui_generate_image
@@ -666,6 +715,7 @@ def register_generation_tools(
         cfg: CfgField = 7.0,
         model: ModelNameField = "",
         wait: WaitField = False,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Transform an existing image using a text prompt (img2img).
 
@@ -702,6 +752,7 @@ def register_generation_tools(
             progress=progress,
             stream_events=False,
             inspect_extra={"image": clean_image, "prompt": prompt, "strength": strength},
+            ctx=ctx,
         )
 
     tool_fns["comfyui_transform_image"] = comfyui_transform_image
@@ -724,6 +775,7 @@ def register_generation_tools(
         cfg: CfgField = 7.0,
         model: ModelNameField = "",
         wait: WaitField = False,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Inpaint regions of an image using a mask and text prompt.
 
@@ -764,6 +816,7 @@ def register_generation_tools(
             progress=progress,
             stream_events=False,
             inspect_extra={"image": clean_image, "mask": clean_mask, "prompt": prompt},
+            ctx=ctx,
         )
 
     tool_fns["comfyui_inpaint_image"] = comfyui_inpaint_image
@@ -787,6 +840,7 @@ def register_generation_tools(
             ),
         ] = "RealESRGAN_x4plus.pth",
         wait: WaitField = False,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Upscale an image using a model-based upscaler.
 
@@ -809,6 +863,7 @@ def register_generation_tools(
             progress=progress,
             stream_events=False,
             inspect_extra={"image": clean_image, "upscale_model": upscale_model},
+            ctx=ctx,
         )
 
     tool_fns["comfyui_upscale_image"] = comfyui_upscale_image

--- a/tests/test_elicitation.py
+++ b/tests/test_elicitation.py
@@ -1,0 +1,269 @@
+"""Tests for elicitation-gated workflow submission (Phase 5).
+
+Verifies that enforce-mode workflows with dangerous-node warnings gate
+through ctx.elicit() — the tool blocks until the user confirms, rather
+than raising WorkflowBlockedError immediately. Audit-mode workflows and
+direct (no-ctx) callers keep the existing behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.progress import WebSocketProgress
+from comfyui_mcp.security.inspector import WorkflowBlockedError, WorkflowInspector
+from comfyui_mcp.tools.generation import _submit_workflow
+
+
+def _wf_with_dangerous_node() -> dict:
+    """A workflow with a suspicious-input warning but no unapproved nodes.
+
+    Uses CLIPTextEncode (an allowed node) with an eval() call in the prompt
+    text — this triggers a suspicious-input warning without the unapproved-node
+    raise that would preempt the elicitation gate. The elicitation fires on
+    inspection.warnings, which suspicious-input warnings populate.
+    """
+    return {
+        "1": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": {"ckpt_name": "model.safetensors"},
+        },
+        "2": {
+            "class_type": "CLIPTextEncode",
+            "inputs": {"text": "eval('malicious')", "clip": ["1", 1]},
+        },
+        "3": {
+            "class_type": "SaveImage",
+            "inputs": {"images": ["1", 0]},
+        },
+    }
+
+
+@pytest.fixture
+def enforce_inspector() -> WorkflowInspector:
+    return WorkflowInspector(
+        mode="enforce",
+        dangerous_nodes=["ExecTextNode"],
+        allowed_nodes=["CheckpointLoaderSimple", "CLIPTextEncode", "SaveImage"],
+    )
+
+
+@pytest.fixture
+def audit_inspector() -> WorkflowInspector:
+    return WorkflowInspector(
+        mode="audit",
+        dangerous_nodes=["ExecTextNode"],
+        allowed_nodes=["CheckpointLoaderSimple", "CLIPTextEncode", "SaveImage"],
+    )
+
+
+@pytest.fixture
+def deps(tmp_path):
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    progress = WebSocketProgress(client)
+    return client, audit, progress
+
+
+class TestEnforceModeElicitationGate:
+    @respx.mock
+    async def test_accept_proceeds_with_submission(self, deps, enforce_inspector):
+        """When the user accepts (data=True), the workflow is submitted
+        despite the enforce-mode warning — the elicitation is the gate."""
+        client, audit, progress = deps
+        respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc-123"})
+        )
+        ctx = AsyncMock()
+        from fastmcp.server.elicitation import AcceptedElicitation
+
+        ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=True))
+
+        result = await _submit_workflow(
+            wf=_wf_with_dangerous_node(),
+            tool_name="run_workflow",
+            success_message="ok",
+            wait=False,
+            client=client,
+            audit=audit,
+            inspector=enforce_inspector,
+            progress=progress,
+            ctx=ctx,
+        )
+        assert result["status"] == "submitted"
+        assert result["prompt_id"] == "abc-123"
+        ctx.elicit.assert_awaited_once()
+
+    @respx.mock
+    async def test_decline_raises_workflow_blocked(self, deps, enforce_inspector):
+        """When the user declines, the workflow is NOT submitted —
+        WorkflowBlockedError propagates without calling post_prompt."""
+        client, audit, progress = deps
+        post_route = respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc"})
+        )
+        ctx = AsyncMock()
+        from fastmcp.server.elicitation import DeclinedElicitation
+
+        ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
+
+        with pytest.raises(WorkflowBlockedError):
+            await _submit_workflow(
+                wf=_wf_with_dangerous_node(),
+                tool_name="run_workflow",
+                success_message="ok",
+                wait=False,
+                client=client,
+                audit=audit,
+                inspector=enforce_inspector,
+                progress=progress,
+                ctx=ctx,
+            )
+        # The POST must not have been called — we blocked before submission.
+        assert post_route.calls.call_count == 0
+        ctx.elicit.assert_awaited_once()
+
+    @respx.mock
+    async def test_cancel_raises_workflow_blocked(self, deps, enforce_inspector):
+        """When the user cancels, the workflow is NOT submitted."""
+        client, audit, progress = deps
+        post_route = respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc"})
+        )
+        ctx = AsyncMock()
+        from fastmcp.server.elicitation import CancelledElicitation
+
+        ctx.elicit = AsyncMock(return_value=CancelledElicitation())
+
+        with pytest.raises(WorkflowBlockedError):
+            await _submit_workflow(
+                wf=_wf_with_dangerous_node(),
+                tool_name="run_workflow",
+                success_message="ok",
+                wait=False,
+                client=client,
+                audit=audit,
+                inspector=enforce_inspector,
+                progress=progress,
+                ctx=ctx,
+            )
+        assert post_route.calls.call_count == 0
+
+    @respx.mock
+    async def test_accept_false_raises_workflow_blocked(self, deps, enforce_inspector):
+        """When the user accepts but answers False (do not proceed), block."""
+        client, audit, progress = deps
+        post_route = respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc"})
+        )
+        ctx = AsyncMock()
+        from fastmcp.server.elicitation import AcceptedElicitation
+
+        ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=False))
+
+        with pytest.raises(WorkflowBlockedError):
+            await _submit_workflow(
+                wf=_wf_with_dangerous_node(),
+                tool_name="run_workflow",
+                success_message="ok",
+                wait=False,
+                client=client,
+                audit=audit,
+                inspector=enforce_inspector,
+                progress=progress,
+                ctx=ctx,
+            )
+        assert post_route.calls.call_count == 0
+
+
+class TestNoCtxFallback:
+    @respx.mock
+    async def test_no_ctx_keeps_raise_behavior(self, deps, enforce_inspector):
+        """Direct callers with no ctx (tests, programmatic) keep the existing
+        behavior: WorkflowBlockedError is raised immediately in enforce mode
+        with warnings. The elicitation gate only fires when ctx is provided."""
+        client, audit, progress = deps
+        post_route = respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc"})
+        )
+        with pytest.raises(WorkflowBlockedError):
+            await _submit_workflow(
+                wf=_wf_with_dangerous_node(),
+                tool_name="run_workflow",
+                success_message="ok",
+                wait=False,
+                client=client,
+                audit=audit,
+                inspector=enforce_inspector,
+                progress=progress,
+            )
+        assert post_route.calls.call_count == 0
+
+
+class TestAuditModeBypassesElicitation:
+    @respx.mock
+    async def test_audit_mode_no_elicitation_even_with_warnings(self, deps, audit_inspector):
+        """Audit mode never blocks and never elicits — warnings are logged
+        and the workflow is submitted."""
+        client, audit, progress = deps
+        respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc-123"})
+        )
+        ctx = AsyncMock()
+
+        result = await _submit_workflow(
+            wf=_wf_with_dangerous_node(),
+            tool_name="run_workflow",
+            success_message="ok",
+            wait=False,
+            client=client,
+            audit=audit,
+            inspector=audit_inspector,
+            progress=progress,
+            ctx=ctx,
+        )
+        assert result["status"] == "submitted"
+        ctx.elicit.assert_not_awaited()
+
+
+class TestNoWarningsNoElicitation:
+    @respx.mock
+    async def test_clean_workflow_no_elicitation_in_enforce_mode(self, deps, enforce_inspector):
+        """A workflow with no warnings in enforce mode is submitted without
+        elicitation — the gate only fires when warnings are present."""
+        client, audit, progress = deps
+        respx.post("http://test:8188/prompt").mock(
+            return_value=httpx.Response(200, json={"prompt_id": "abc-123"})
+        )
+        ctx = AsyncMock()
+
+        clean_wf = {
+            "1": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": {"ckpt_name": "model.safetensors"},
+            },
+            "2": {
+                "class_type": "SaveImage",
+                "inputs": {"images": ["1", 0]},
+            },
+        }
+
+        result = await _submit_workflow(
+            wf=clean_wf,
+            tool_name="run_workflow",
+            success_message="ok",
+            wait=False,
+            client=client,
+            audit=audit,
+            inspector=enforce_inspector,
+            progress=progress,
+            ctx=ctx,
+        )
+        assert result["status"] == "submitted"
+        ctx.elicit.assert_not_awaited()


### PR DESCRIPTION
Closes #127. Part of epic #122.

## What

Phase 5 of the FastMCP 4 migration. Converts the workflow inspector's dangerous-node confirmation flow from a soft documentation hint into a **protocol-level gate** — the tool itself blocks until the user confirms, rather than relying on the LLM to relay a soft warning.

### `src/comfyui_mcp/tools/generation.py`
- `_submit_workflow()` gains an optional `ctx: Context | None = None` param. When `ctx` is provided and `inspector.mode == "enforce"` and `inspection.warnings` is non-empty, the user is asked to confirm via `ctx.elicit(message, response_type=bool)` before submission. Accept with `data=True` proceeds; decline/cancel/accept-False raises `WorkflowBlockedError` without calling `post_prompt`.
- All 6 generation tools (`run_workflow`, `run_workflow_stream`, `generate_image`, `transform_image`, `inpaint_image`, `upscale_image`) get a `ctx: Context | None = None` param (FastMCP auto-injects `Context`, not in the schema) and pass `ctx=ctx` to `_submit_workflow`.
- **Direct/test callers** (`ctx=None`) keep the pre-existing behavior: `WorkflowBlockedError` raised immediately in enforce mode with warnings.
- **Unapproved-node enforcement** (the `allowed_nodes` allowlist) still blocks hard inside `inspector.inspect()` before elicitation — the gate fires on the *warning* path (dangerous-node types, suspicious inputs like `eval()`/`exec()`, missing models).

## Process (red → green)

- **Red**: wrote `tests/test_elicitation.py` first; confirmed `_submit_workflow() got an unexpected keyword argument 'ctx'` (6 of 7 failing)
- **Green**: added `ctx` param + elicitation gate to `_submit_workflow`, threaded `ctx: Context | None` through all 6 generation tools, all tests pass

## Verification

- [x] `uv run pytest` — **572 passed** (7 new + 565 existing)
- [x] `uv run mypy src/comfyui_mcp/` — clean (35 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pre-commit run --all-files` — green
- [x] README.md — documented the elicitation gate in the Enforce mode section

## Notes

- The elicitation uses the **handshake-era** `ctx.elicit()` API. The modern-protocol (2026-07-28) guard pattern (`InputRequiredResult`) is a follow-up if the server needs to serve 2026-07-28 connections — branch on `ctx.request_context.protocol_version`. `fastmcp.Client` drives the loop automatically for both eras when configured with an `elicitation_handler`.
- Clients that do not implement an elicitation handler get a clear error; the fallback (`ctx=None`) preserves current behavior for direct/test callers.
- Rule 22 (Phase 4 eval) applies — this is a behavior change at the tool boundary (enforce mode now elicits instead of immediately raising for the warning path). Flagging for reviewer judgment on whether to run the eval pre-merge; unapproved-node enforcement is unchanged, only the warning path now elicits.

## Do not

- No background tasks — that is #128.

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>