### PR TITLE
Update documentation for the FastMCP 4 migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,20 +34,34 @@ When a rule and this file disagree, the rule wins.
 
 ## Project Overview
 
-A secure MCP (Model Context Protocol) server for ComfyUI. Enables AI assistants
-to generate images, run workflows, and manage jobs through ComfyUI with built-in
-security controls:
-- Workflow Inspector (detects dangerous nodes like `eval`, `exec`)
+A secure MCP (Model Context Protocol) server for ComfyUI, built on
+**FastMCP 4**. Enables AI assistants to generate images, run workflows, and
+manage jobs through ComfyUI with built-in security controls:
+- Workflow Inspector (detects dangerous nodes like `eval`, `exec`) with
+  **user elicitation** — enforce mode asks the user to confirm before
+  submitting a flagged workflow
 - Path Sanitizer (blocks path traversal attacks)
-- Rate Limiter (token-bucket per tool category)
-- Audit Logger (structured JSON logging)
+- **SecurityMiddleware** — centralized rate limiting + entry audit logging
+  (FastMCP 4 `on_call_tool` hook) across every tool call
+- Audit Logger (structured JSON logging with redaction)
 - Selective API surface (blocks dangerous endpoints)
+- **Resources** — read-only ComfyUI state the LLM can browse by URI
+  (`comfyui://models/{folder}`, `comfyui://nodes/installed`, `comfyui://queue`,
+  `comfyui://system`)
+- **Prompts** — reusable workflow-template recipes (txt2img, img2img,
+  inpaint, upscale)
+- **Dependency injection** — `Depends()` providers for the
+  `client`/`audit`/`inspector`/`limiter` singletons (opt-in per tool module;
+  the `register_*_tools()` factory remains valid)
+- **Background tasks** (optional) — `TasksExtension` (Docket-backed) for
+  long-running workflows over the HTTP transport
 
 ## Tech Stack
 
 - **Python**: 3.12
 - **Package Manager**: uv
-- **MCP Framework**: fastmcp[tasks] 4.0.0b1 (standalone FastMCP 4 beta)
+- **MCP Framework**: fastmcp[tasks] 4.0.0b1 (standalone FastMCP 4 beta,
+  built on MCP SDK v2)
 - **HTTP Client**: httpx (async)
 - **Validation**: pydantic
 - **Config**: pyyaml
@@ -56,10 +70,14 @@ security controls:
 
 ```
 src/comfyui_mcp/
-├── server.py              # MCP server entry, wires all components
+├── server.py              # MCP server entry, wires all components + middleware
 ├── config.py              # Pydantic settings, YAML loading, env overrides
 ├── client.py              # Async HTTP client for ComfyUI API
 ├── audit.py               # Structured JSON audit logger
+├── middleware.py          # SecurityMiddleware (rate limit + entry audit, on_call_tool)
+├── dependencies.py        # Depends() providers (client/audit/inspector/limiter singletons)
+├── resources.py           # @mcp.resource URIs (models, nodes, queue, system)
+├── prompts.py             # @mcp.prompt workflow-template recipes
 ├── model_manager.py       # Lazy Model Manager detection and folder caching
 ├── model_registry.py      # Canonical model loader field registry
 ├── node_manager.py        # ComfyUI Manager detector
@@ -77,11 +95,12 @@ src/comfyui_mcp/
 │   ├── operations.py      # Workflow graph operations (add/remove nodes, connect)
 │   └── validation.py      # Workflow analysis and validation
 └── tools/
-    ├── generation.py      # generate_image, run_workflow, summarize_workflow
+    ├── generation.py      # generate_image, run_workflow, summarize_workflow (elicitation-gated)
     ├── workflow.py        # create_workflow, modify_workflow, validate_workflow
     ├── jobs.py            # get_queue, get_job, cancel_job, interrupt, get_progress
     ├── discovery.py       # list_models, list_nodes, audit_dangerous_nodes, etc.
-    ├── history.py         # get_history
+    ├── history.py         # get_history (factory version)
+    ├── history_di.py      # get_history (DI version — Depends() proof module)
     ├── files.py           # upload_image, get_image, list_outputs, upload_mask, get_workflow_from_image
     ├── models.py          # search_models, download_model, get_download_tasks, cancel_download
     └── nodes.py           # search/install/uninstall/update custom nodes
@@ -151,11 +170,12 @@ Config file: `~/.comfyui-mcp/config.yaml`
 
 Key settings:
 - `comfyui.url` — ComfyUI server URL
-- `security.mode` — "audit" (log only) or "enforce" (block unapproved nodes)
+- `security.mode` — "audit" (log only) or "enforce" (block unapproved nodes, elicit user on warnings)
 - `security.dangerous_nodes` — List of node types to flag/warn
 - `rate_limits.*` — Requests per minute per category
+- `tasks.enabled` — Optional background tasks (Phase 6); `tasks.backend_url` selects memory vs redis
 
-Environment variables override config: `COMFYUI_URL`, `COMFYUI_SECURITY_MODE`, etc.
+Environment variables override config: `COMFYUI_URL`, `COMFYUI_SECURITY_MODE`, `COMFYUI_TASKS_ENABLED`, `COMFYUI_TASKS_BACKEND_URL`, etc.
 
 ## Testing Notes
 
@@ -177,14 +197,23 @@ Two known quirks discovered against the live API:
 
 1. Add the tool function in the appropriate `tools/*.py`
 2. Use `@mcp.tool()` decorator with a clear docstring
-3. Call `limiter.check("tool_name")` first (or rely on `RateLimitingMiddleware`)
-4. Call `audit.log(tool="tool_name", action="...")` (or rely on `AuditMiddleware`)
+3. Ensure rate limiting is in effect — in-tool `limiter.check("tool_name")`
+   OR rely on `SecurityMiddleware` (wired in `server.py`); add the tool to
+   `_TOOL_CATEGORIES` if using the middleware path
+4. Ensure audit logging is in effect — in-tool `audit.async_log(...)` OR
+   rely on `SecurityMiddleware` (it writes the `action="called"` entry
+   record; keep lifecycle logs like `submitted`/`completed` in the tool)
 5. If it handles files: validate through `sanitizer`
-6. If it submits workflows: inspect through `inspector`
+6. If it submits workflows: inspect through `inspector` (and pass `ctx` to
+   `_submit_workflow` for the elicitation gate in enforce mode)
 7. Use `Annotated[type, Field(...)]` for parameters with constraints (3+ params)
 8. Return `dict[str, Any]` if all code paths return structured data; use `-> str` only for mixed return paths
-9. Add the function to the `tool_fns` dict and return it (or define as a module-level decorated function with `Depends()`)
-10. Wire it in `server.py` `_register_all_tools()` if it needs new dependencies
+9. Either add the function to the `tool_fns` dict and return it (factory
+   pattern), *or* define it as a module-level decorated function with
+   `Depends()` for DI (see `tools/history_di.py` for the pattern)
+10. Wire it in `server.py` `_register_all_tools()` if it uses the factory
+    pattern and needs new dependencies (module-level decorated functions
+    with `Depends()` skip this — the decorator registers them)
 11. Add tests in `tests/test_tools_*.py` that call the function directly
 12. Update the Tools table in `README.md`
 
@@ -199,8 +228,26 @@ Two known quirks discovered against the live API:
 
 1. Add to the appropriate module in `security/`
 2. Wire it in `server.py` `_build_server()` and pass to tool registration
+   (or add to `SecurityMiddleware` if it is a cross-cutting concern)
 3. Add config fields to `config.py` if needed — every field must be read somewhere
 4. Add tests in `tests/test_*.py`
+
+## Adding a new resource or prompt (checklist)
+
+1. Add the `@mcp.resource("comfyui://...")` function in `resources.py` (for
+   read-only state) or the `@mcp.prompt` function in `prompts.py` (for
+   workflow recipes). Register in `server.py` `_register_all_tools()`.
+2. Templated resources (`comfyui://.../{param}`) inherit FastMCP 4's
+   path-traversal screening (on by default); still anchor the final path
+   against an allowed root and confirm containment before reading.
+3. Prompts return a plain string (auto-wrapped as a user message) or
+   `list[Message]` for multi-turn — not `mcp.types.PromptMessage` or raw
+   role/content dicts.
+4. Resources/prompts use the read-only rate limiter; add a `limiter.check()`
+   call and an `audit.async_log()` entry record (or rely on
+   `SecurityMiddleware`).
+5. Add tests in `tests/test_resources.py` / `tests/test_prompts.py` that call
+   the function directly.
 
 ## Maintaining the dangerous nodes list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Agent harness switched to OpenCode** — Claude Code and GitHub Copilot
-  tooling removed. The repo now ships agent configuration under `.opencode/`
-  (`opencode.json`, path-scoped `rules/`, a read-only `review` subagent, a
-  `/preflight` command, a zero-skip test hook, and a graphify plugin) and an
-  `AGENTS.md` entry point. `CLAUDE.md` remains as a flat mirror of the rules
-  for harnesses that read it directly; the path-scoped `.opencode/rules/` files
-  are the source of truth. The server itself was already harness-agnostic (any
-  MCP client over stdio or Streamable HTTP).
+- **Migrated to FastMCP 4 beta** (`fastmcp[tasks]==4.0.0b1`, built on MCP SDK
+  v2). The server now imports `FastMCP` from `fastmcp` instead of the
+  `mcp.server.fastmcp` bundle bundled in `mcp` v1. `ToolAnnotations` field
+  arguments converted from camelCase to snake_case (`readOnlyHint` →
+  `read_only_hint`, etc.). `host`/`port` transport settings moved from the
+  `FastMCP()` constructor to `mcp.run()`; the streamable-HTTP transport is
+  now named `"http"` internally (#123, #129).
+- **Consolidated `CLAUDE.md` into `AGENTS.md`** — single harness-agnostic
+  entry point, no more Claude Code coupling. All live references in tests,
+  the review subagent, and rules updated (#123, #129).
+- **Updated `.opencode/rules/`** to permit the cleaner architecture the
+  migration unlocks: security rules 3/4 accept middleware enforcement as
+  an alternative to in-tool calls; architecture rule 11 accepts
+  module-level `Depends()`-decorated functions alongside the
+  `register_*_tools()` factory; tools.md checklist rewritten for dual
+  enforcement paths and DI; testing rule 19 covers both enforcement paths
+  (#123, #129).
+
+### Added
+
+- **Resources** (`resources.py`) — read-only ComfyUI state the LLM can
+  browse by URI without a tool call: `comfyui://models/{folder}`,
+  `comfyui://nodes/installed`, `comfyui://queue`, `comfyui://system`.
+  Templated resources inherit FastMCP 4's built-in path-traversal screening
+  (#124, #130).
+- **Prompts** (`prompts.py`) — reusable workflow-template recipes
+  (`txt2img_prompt`, `img2img_prompt`, `inpaint_prompt`, `upscale_prompt`)
+  returning a plain string auto-wrapped as a user message (#124, #130).
+- **`SecurityMiddleware`** (`middleware.py`) — centralizes rate-limit
+  checks + entry audit logging across every tool call via the FastMCP 4
+  `on_call_tool` hook. Sensitive tool arguments are redacted before the
+  audit record is written. `mask_error_details=True` on the server
+  constructor masks internal exception tracebacks from clients (#125,
+  #131).
+- **Dependency injection** (`dependencies.py`) — `Depends()` providers
+  for the `client`/`audit`/`inspector`/`limiter` singletons
+  (`configure_dependencies()` at startup). `tools/history_di.py` is the
+  proof module; the remaining tools migrate incrementally. Per-file
+  `B008` ruff ignore for the `Depends()`-in-default idiom (#126, #132).
+- **Elicitation gate** — enforce-mode workflows with dangerous-node or
+  suspicious-input warnings now `ctx.elicit()` the user for confirmation
+  before submission. Decline/cancel raises `WorkflowBlockedError` without
+  calling `post_prompt`. Direct/test callers without a `Context` keep the
+  pre-existing behavior (#127, #133).
+- **Background tasks** (optional) — `TasksExtension` (Docket-backed) for
+  long-running workflows over the HTTP transport. Disabled by default;
+  `tasks.enabled` config + `COMFYUI_TASKS_ENABLED`/
+  `COMFYUI_TASKS_BACKEND_URL` env overrides. In-memory (`memory://`) or
+  Redis (`redis://host:port/db`) backends (#128, #134).
 
 ### Removed
 
+- **`CLAUDE.md`** — consolidated into `AGENTS.md` (no more Claude Code
+  coupling). The path-scoped `.opencode/rules/` files are the source of
+  truth (#123, #129).
 - **Claude Code plugin** — `.claude-plugin/`, `.claude/`, `.mcp.json`, and the
   `hooks/` directory (Claude `PostToolUse` security-warning hook) removed.
   Security warnings already surface in the MCP tool response envelope
@@ -28,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Copilot instructions** — `.github/copilot-instructions.md` and
   `.github/instructions/` removed.
 
-### Added
+### Added (agent tooling)
 
 - **`.opencode/`** — `opencode.json` (wires `context7` + `graphify` MCP
   servers, `review` subagent, `/preflight` command, graphify plugin,

--- a/README.md
+++ b/README.md
@@ -12,11 +12,23 @@ This server adds five security layers between the AI assistant and ComfyUI:
 
 | Layer | What it does |
 |-------|-------------|
-| **Workflow Inspector** | Parses every workflow before execution, extracts node types, flags dangerous patterns (`eval`, `exec`, `__import__`, `subprocess`). Configurable audit-only or enforcement mode. |
-| **Path Sanitizer** | Validates all filenames, subfolders, and URL path segments — blocks path traversal (`../`), null bytes, percent-encoded attacks, absolute paths, and disallowed file extensions. |
-| **Rate Limiter** | Token-bucket rate limiting per tool category to prevent runaway loops. |
+| **Workflow Inspector** | Parses every workflow before execution, extracts node types, flags dangerous patterns (`eval`, `exec`, `__import__`, `subprocess`). Configurable audit-only or enforcement mode. In enforce mode, dangerous-node and suspicious-input warnings **elicit the user** for confirmation before submission. |
+| **Path Sanitizer** | Validates all filenames, subfolders, and URL path segments — blocks path traversal (`../`), null bytes, percent-encoded attacks, absolute paths, and disallowed file extensions. Templated resources (`comfyui://models/{folder}`) also inherit FastMCP 4's built-in path-traversal screening. |
+| **SecurityMiddleware** | Centralized rate-limit checks + entry audit logging across every tool call via the FastMCP 4 `on_call_tool` hook. Sensitive tool arguments (`token`, `password`, `api_key`) are redacted before the audit record is written. |
 | **Audit Logger** | Structured JSON logging of every operation with automatic redaction of sensitive fields (tokens, passwords). |
 | **Selective API Surface** | Only exposes safe ComfyUI endpoints. Dangerous endpoints (`/userdata`, `/free`, `/users`) are never proxied. `/system_stats` is called internally by `comfyui_get_system_info` but only a strict whitelist (GPU VRAM, queue counts, version) is returned. |
+
+### Resources & Prompts (FastMCP 4)
+
+The server exposes read-only ComfyUI state as **resources** the LLM can browse by URI without a tool call, and **prompts** as reusable workflow-template recipes:
+
+- **Resources**: `comfyui://models/{folder}`, `comfyui://nodes/installed`, `comfyui://queue`, `comfyui://system`
+- **Prompts**: `txt2img_prompt`, `img2img_prompt`, `inpaint_prompt`, `upscale_prompt`
+
+### Dependency injection & background tasks (FastMCP 4)
+
+- **Depends() DI** — tool modules may declare their dependencies (`client`, `audit`, `inspector`, `limiter`) via `Depends()` providers (auto-excluded from the MCP schema) instead of receiving them through `register_*_tools()` factories. Both patterns are valid; `history_di.py` is the proof module, with the remaining tools migrating incrementally.
+- **Background tasks** (optional) — long-running workflows can run as background tasks via `TasksExtension` (Docket-backed) instead of holding the request open. Disabled by default; see [Background tasks](#background-tasks-optional-phase-6).
 
 ### Real-time progress tracking
 
@@ -482,6 +494,8 @@ Environment variables override config file values:
 | `COMFYUI_CIVITAI_API_KEY` | `model_search.civitai_api_key` |
 | `COMFYUI_MAX_SEARCH_RESULTS` | `model_search.max_search_results` |
 | `COMFYUI_ALLOWED_DOWNLOAD_DOMAINS` | `security.allowed_download_domains` |
+| `COMFYUI_TASKS_ENABLED` | `tasks.enabled` (optional background tasks) |
+| `COMFYUI_TASKS_BACKEND_URL` | `tasks.backend_url` (`memory://` or `redis://...`) |
 
 ### HuggingFace and CivitAI API keys
 
@@ -687,19 +701,26 @@ flowchart TB
         MC[AI Assistant / MCP Client]
     end
 
-    subgraph MCP["ComfyUI MCP Server"]
+    subgraph MCP["ComfyUI MCP Server (FastMCP 4)"]
         CONFIG[Config<br/>YAML/env]
         AL[Audit Logger<br/>JSON logs]
 
         subgraph Security["Security Layers"]
-            WI[Workflow Inspector<br/>Dangerous nodes<br/>Suspicious input]
+            WI[Workflow Inspector<br/>Dangerous nodes<br/>Suspicious input<br/>+ Elicitation gate]
             PS[Path Sanitizer<br/>Traversal block<br/>Extension filter]
             RL[Rate Limiter<br/>Token-bucket]
         end
 
+        MW[SecurityMiddleware<br/>rate limit + entry audit<br/>on_call_tool hook]
+        DI[Dependencies<br/>Depends() providers]
+
         subgraph Tools["Tool Groups"]
-            TG[generation.py<br/>jobs.py<br/>discovery.py<br/>history.py<br/>files.py]
+            TG[generation.py<br/>jobs.py<br/>discovery.py<br/>history.py / history_di.py<br/>files.py]
         end
+
+        RES[Resources<br/>comfyui://models, nodes, queue, system]
+        PR[Prompts<br/>txt2img, img2img, inpaint, upscale]
+        TASKS[TasksExtension<br/>optional, Docket-backed]
 
         API[ComfyUI Client<br/>httpx]
         WS[WebSocket Progress<br/>websockets]
@@ -714,7 +735,10 @@ flowchart TB
     CONFIG --> MCP
     AL --> MCP
 
-    MCP --> Security
+    MCP --> MW
+    MW --> Security
+    MW --> Tools
+    DI --> Tools
     Security --> Tools
     Tools --> API
     Tools --> WS
@@ -726,15 +750,19 @@ flowchart TB
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| Server | `server.py` | Entry point, wires components, registers tools |
-| Config | `config.py` | Pydantic settings, YAML loading, env overrides |
+| Server | `server.py` | Entry point, wires components, registers tools/resources/prompts/middleware |
+| Config | `config.py` | Pydantic settings, YAML loading, env overrides (incl. `tasks.*`) |
 | Client | `client.py` | Async HTTP client for ComfyUI REST API |
+| SecurityMiddleware | `middleware.py` | Centralized rate-limit + entry-audit via FastMCP 4 `on_call_tool` hook |
+| Dependencies | `dependencies.py` | `Depends()` providers for client/audit/inspector/limiter singletons |
+| Resources | `resources.py` | `@mcp.resource` URIs — models, nodes, queue, system (read-only browsing) |
+| Prompts | `prompts.py` | `@mcp.prompt` workflow-template recipes (txt2img, img2img, inpaint, upscale) |
 | Progress | `progress.py` | WebSocket progress tracking with HTTP polling fallback |
 | Audit | `audit.py` | Structured JSON logging with redaction |
-| Workflow Inspector | `security/inspector.py` | Node type detection, dangerous pattern matching |
+| Workflow Inspector | `security/inspector.py` | Node type detection, dangerous pattern matching, elicitation gate |
 | Node Auditor | `security/node_auditor.py` | Scans installed nodes for dangerous patterns |
 | Path Sanitizer | `security/sanitizer.py` | Path traversal, extension filtering |
-| Rate Limiter | `security/rate_limit.py` | Token-bucket per tool category |
+| Rate Limiter | `security/rate_limit.py` | Token-bucket per tool category (enforced by `SecurityMiddleware`) |
 | Download Validator | `security/download_validator.py` | URL domain/path and extension validation for downloads |
 | Model Checker | `security/model_checker.py` | Proactive missing model detection in workflows |
 | Model Manager | `model_manager.py` | Lazy detection of ComfyUI-Model-Manager availability |
@@ -745,9 +773,13 @@ flowchart TB
 
 ```text
 src/comfyui_mcp/
-├── server.py              # MCP server entry point, wires all components
+├── server.py              # MCP server entry point, wires all components + middleware
 ├── config.py              # Pydantic settings, YAML loading, env overrides
 ├── client.py              # Async HTTP client for ComfyUI API
+├── middleware.py          # SecurityMiddleware (rate limit + entry audit, on_call_tool)
+├── dependencies.py        # Depends() providers (client/audit/inspector/limiter singletons)
+├── resources.py           # @mcp.resource URIs (models, nodes, queue, system)
+├── prompts.py             # @mcp.prompt workflow-template recipes
 ├── progress.py            # WebSocket progress tracking with HTTP polling fallback
 ├── pagination.py          # Offset-based pagination helper for list tools
 ├── audit.py               # Structured JSON audit logger
@@ -764,11 +796,12 @@ src/comfyui_mcp/
 │   ├── operations.py      # Workflow graph operations (add/remove nodes, connect, etc.)
 │   └── validation.py      # Workflow analysis and validation
 └── tools/
-    ├── generation.py      # generate_image, run_workflow, summarize_workflow
+    ├── generation.py      # generate_image, run_workflow, summarize_workflow (elicitation-gated)
     ├── workflow.py        # create_workflow, modify_workflow, validate_workflow, analyze_workflow
     ├── jobs.py            # get_queue, get_job, cancel_job, interrupt, get_progress
     ├── discovery.py       # list_models, list_nodes, audit_dangerous_nodes, etc.
-    ├── history.py         # get_history
+    ├── history.py         # get_history (factory version)
+    ├── history_di.py      # get_history (DI version — Depends() proof module)
     ├── files.py           # upload_image, get_image, list_outputs, upload_mask, get_workflow_from_image
     ├── models.py          # search_models, download_model, get_download_tasks, cancel_download
     └── nodes.py           # search/install/uninstall/update custom nodes


### PR DESCRIPTION
Updates AGENTS.md, README.md, and CHANGELOG.md to reflect the six-phase FastMCP 4 migration (#122).

## What

Markdown-only changes that bring the documentation surfaces in line with the merged code (PRs #129, #130, #131, #132, #133, #134).

### `AGENTS.md`
- **Project Overview** — documents the new features (elicitation, middleware, resources, prompts, DI, background tasks)
- **Tech Stack** — notes `fastmcp[tasks] 4.0.0b1` is built on MCP SDK v2
- **Project Structure** — adds `middleware.py`, `dependencies.py`, `resources.py`, `prompts.py`, `tools/history_di.py` to the tree (verified against actual `src/` layout)
- **Configuration** — adds `tasks.*` settings + `COMFYUI_TASKS_*` env overrides
- **New-tool checklist** — dual enforcement paths (in-tool OR `SecurityMiddleware`), `Depends()` DI option, `ctx` for the elicitation gate
- **New resource/prompt checklist** added
- **Security-check checklist** — mentions `SecurityMiddleware` wiring

### `README.md`
- **Security layers table** — elicitation gate, path-traversal screening on templated resources, `SecurityMiddleware` for rate-limit + entry-audit
- **New sections** — Resources & Prompts, Dependency injection & background tasks
- **Architecture diagram** — adds `MW` (SecurityMiddleware), `DI` (Depends), `RES` (Resources), `PR` (Prompts), `TASKS` nodes; FastMCP 4 label
- **Components table** — adds middleware, dependencies, resources, prompts, history_di rows
- **Project structure tree** — includes the new modules
- **Environment variables** — adds `COMFYUI_TASKS_ENABLED`, `COMFYUI_TASKS_BACKEND_URL`

### `CHANGELOG.md` (Unreleased)
- **Changed** — FastMCP 4 migration (imports, `ToolAnnotations` snake_case, host/port move, transport name), `CLAUDE.md` consolidation, rules updates
- **Added** — resources, prompts, `SecurityMiddleware`, `Depends()` DI, elicitation gate, background tasks (each with issue + PR refs)
- **Removed** — `CLAUDE.md` (consolidated), Claude Code plugin, Copilot instructions
- Stale entry that said "`CLAUDE.md` remains as a flat mirror" corrected (it was deleted in #129)

## Verification

- [x] `uv run pre-commit run --all-files` — green (markdown-only changes; ruff/mypy skip cleanly)
- [x] `AGENTS.md` structure tree verified against actual `src/comfyui_mcp/` layout (file-by-file match)
- [x] No stale `mcp[cli]` / `CLAUDE.md` / `streamable-http` references in source/docs — only SDK internals (`.venv`) and one rename-explaining comment in `server.py` remain
- [x] `CONTRIBUTING.md` has no Claude references

## Notes

- The `[Unreleased]` section groups the agent-harness switch and the FastMCP 4 migration together since both ship before the next release. PR refs (`#129`, `#130`, …) point at the squash-merge PRs, not the issues, so reviewers can trace each entry to the merged commit.

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>