### PR TITLE
Extend SecurityMiddleware to cover resources and prompts (#136)

### DIFF
--- a/src/comfyui_mcp/middleware.py
+++ b/src/comfyui_mcp/middleware.py
@@ -21,7 +21,7 @@ replaces the generic *entry* audit + the rate-limit check.
 
 from __future__ import annotations
 
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import PromptError, ResourceError, ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from comfyui_mcp.audit import AuditLogger, _redact_sensitive
@@ -90,6 +90,51 @@ class SecurityMiddleware(Middleware):
             extra={"arguments": redacted},
         )
 
+        return await call_next(context)
+
+    async def on_read_resource(self, context: MiddlewareContext, call_next):
+        # Closes the #136 gap: on_call_tool fires for tools only, so resources
+        # need their own hook for security rules 3 and 4. The message is a
+        # ReadResourceRequestParams carrying `uri`.
+        message = context.message
+        uri = str(getattr(message, "uri", None) or "<unknown>")
+        component_name = f"resource:{uri}"
+
+        limiter = self._limiter_for(component_name)
+        try:
+            limiter.check(component_name)
+        except RateLimitError as e:
+            raise ResourceError(str(e)) from e
+
+        await self._audit.async_log(
+            tool=component_name,
+            action="called",
+            extra={"uri": uri},
+        )
+        return await call_next(context)
+
+    async def on_get_prompt(self, context: MiddlewareContext, call_next):
+        # Closes the #136 gap for prompts. The message is a
+        # GetPromptRequestParams carrying `name` and `arguments`.
+        message = context.message
+        prompt_name = getattr(message, "name", None) or "<unknown>"
+        arguments = getattr(message, "arguments", None) or {}
+        component_name = f"prompt:{prompt_name}"
+
+        limiter = self._limiter_for(component_name)
+        try:
+            limiter.check(component_name)
+        except RateLimitError as e:
+            raise PromptError(str(e)) from e
+
+        redacted: dict[str, object] = (
+            _redact_sensitive(dict(arguments)) if isinstance(arguments, dict) else {}
+        )
+        await self._audit.async_log(
+            tool=component_name,
+            action="called",
+            extra={"arguments": redacted},
+        )
         return await call_next(context)
 
 

--- a/tests/test_middleware_resource_prompt.py
+++ b/tests/test_middleware_resource_prompt.py
@@ -1,0 +1,113 @@
+"""Tests for SecurityMiddleware coverage of resources and prompts (#136).
+
+Verifies the middleware's on_read_resource and on_get_prompt hooks fire
+for resources and prompts — closing the gap where the original on_call_tool
+hook covered tools only, leaving resources/prompts enforced solely by
+in-tool calls with no test guardrail.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.middleware import SecurityMiddleware
+from comfyui_mcp.security.rate_limit import RateLimiter
+
+
+def _read_audit_lines(audit_file: Path) -> list[dict]:
+    if not audit_file.exists():
+        return []
+    lines = audit_file.read_text().strip().splitlines()
+    return [json.loads(line) for line in lines if line]
+
+
+@pytest.fixture
+def rate_limiters() -> dict[str, RateLimiter]:
+    return {
+        "read": RateLimiter(max_per_minute=60),
+        "workflow": RateLimiter(max_per_minute=10),
+        "generation": RateLimiter(max_per_minute=10),
+        "file": RateLimiter(max_per_minute=30),
+    }
+
+
+class TestOnReadResourceHook:
+    async def test_resource_read_writes_audit_record(self, tmp_path, rate_limiters):
+        """on_read_resource fires for resource reads, writing an entry audit
+        record keyed by the resource URI — not just the on_call_tool path."""
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.resource("comfyui://models/checkpoints")
+        async def models_resource() -> str:
+            return json.dumps({"models": ["a.safetensors"]})
+
+        mcp.add_middleware(middleware)
+
+        result = await mcp.read_resource("comfyui://models/checkpoints")
+        assert result.contents  # the read succeeded
+        records = _read_audit_lines(tmp_path / "audit.log")
+        assert any(r["action"] == "called" for r in records), (
+            "on_read_resource did not write an entry audit record — resources "
+            "have no enforcement coverage without this hook (security rule 4)"
+        )
+
+    async def test_resource_read_rate_limited(self, tmp_path, rate_limiters):
+        """on_read_resource enforces the rate limit — a second read past the
+        bucket is blocked (security rule 3 for resources)."""
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        rate_limiters["read"] = RateLimiter(max_per_minute=1)
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.resource("comfyui://test")
+        async def r() -> str:
+            return "ok"
+
+        mcp.add_middleware(middleware)
+        first = await mcp.read_resource("comfyui://test")
+        assert first.contents
+        from fastmcp.exceptions import ResourceError
+
+        with pytest.raises(ResourceError, match="Rate limit exceeded"):
+            await mcp.read_resource("comfyui://test")
+
+
+class TestOnGetPromptHook:
+    async def test_prompt_get_writes_audit_record(self, tmp_path, rate_limiters):
+        """on_get_prompt fires for prompt retrieval, writing an entry audit
+        record keyed by the prompt name — security rule 4 for prompts."""
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        middleware = SecurityMiddleware(
+            audit=audit,
+            rate_limiters=rate_limiters,
+            tool_categories={},
+        )
+        mcp = FastMCP("test")
+
+        @mcp.prompt
+        def greeting(name: str) -> str:
+            return f"hi {name}"
+
+        mcp.add_middleware(middleware)
+        result = await mcp.render_prompt("greeting", {"name": "world"})
+        assert result  # the render succeeded
+        records = _read_audit_lines(tmp_path / "audit.log")
+        assert any(r["action"] == "called" for r in records), (
+            "on_get_prompt did not write an entry audit record — prompts have "
+            "no enforcement coverage without this hook (security rule 4)"
+        )

--- a/tests/test_security_invariants.py
+++ b/tests/test_security_invariants.py
@@ -29,6 +29,8 @@ from comfyui_mcp.config import ModelSearchSettings
 from comfyui_mcp.model_manager import ModelManagerDetector
 from comfyui_mcp.node_manager import ComfyUIManagerDetector
 from comfyui_mcp.progress import WebSocketProgress
+from comfyui_mcp.prompts import register_prompts
+from comfyui_mcp.resources import register_resources
 from comfyui_mcp.security.download_validator import DownloadValidator
 from comfyui_mcp.security.inspector import WorkflowInspector
 from comfyui_mcp.security.model_checker import ModelChecker
@@ -234,4 +236,83 @@ class TestInspectorInvariant:
         assert not missing, (
             f"{len(missing)} workflow-submitting tool(s) have no WorkflowInspector in closure — "
             f"cannot enforce security rule 5: {sorted(missing)}"
+        )
+
+
+# --- Resources and prompts (#136) ---
+# The all_tools fixture above covers factory tools only. Resources and prompts
+# are registered separately and need their own closure invariant check —
+# without this, removing their in-tool limiter/audit calls (which the
+# SecurityMiddleware on_read_resource/on_get_prompt hooks now cover) would
+# not be caught by any test.
+
+
+@pytest.fixture
+def all_components(tmp_path: Path) -> Iterator[dict[str, Any]]:
+    """Build the resource and prompt functions with real wiring."""
+    client = ComfyUIClient(base_url="http://mock-comfyui:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    sanitizer = PathSanitizer(allowed_extensions=[".png", ".jpg", ".json"])
+    rl_read = RateLimiter(max_per_minute=60)
+    mcp = FastMCP("invariants-components-test")
+    components: dict[str, Any] = {}
+    components.update(register_resources(mcp, client, audit, rl_read, sanitizer))
+    components.update(register_prompts(mcp, client, audit, rl_read, sanitizer))
+    yield components
+
+
+class TestResourceRateLimiterInvariant:
+    """Security rule 3 for resources: each resource closure must have a
+    RateLimiter (in-tool enforcement path). The middleware on_read_resource
+    hook is the framework path; both are covered."""
+
+    def test_resources_have_rate_limiter_in_closure(self, all_components: dict[str, Any]) -> None:
+        resource_fns = {k: v for k, v in all_components.items() if k.startswith("comfyui_")}
+        assert resource_fns, "No resource functions registered — fixture is broken"
+        missing = [
+            name for name, fn in resource_fns.items() if not _has_instance_of(fn, RateLimiter)
+        ]
+        assert not missing, (
+            f"{len(missing)} resource(s) have no RateLimiter in closure — "
+            f"cannot enforce security rule 3 for resources: {sorted(missing)}"
+        )
+
+
+class TestResourceAuditInvariant:
+    """Security rule 4 for resources: each resource closure must have an
+    AuditLogger."""
+
+    def test_resources_have_audit_logger_in_closure(self, all_components: dict[str, Any]) -> None:
+        resource_fns = {k: v for k, v in all_components.items() if k.startswith("comfyui_")}
+        missing = [
+            name for name, fn in resource_fns.items() if not _has_instance_of(fn, AuditLogger)
+        ]
+        assert not missing, (
+            f"{len(missing)} resource(s) have no AuditLogger in closure — "
+            f"cannot enforce security rule 4 for resources: {sorted(missing)}"
+        )
+
+
+class TestPromptRateLimiterInvariant:
+    """Security rule 3 for prompts."""
+
+    def test_prompts_have_rate_limiter_in_closure(self, all_components: dict[str, Any]) -> None:
+        prompt_fns = {k: v for k, v in all_components.items() if k.endswith("_prompt")}
+        assert prompt_fns, "No prompt functions registered — fixture is broken"
+        missing = [name for name, fn in prompt_fns.items() if not _has_instance_of(fn, RateLimiter)]
+        assert not missing, (
+            f"{len(missing)} prompt(s) have no RateLimiter in closure — "
+            f"cannot enforce security rule 3 for prompts: {sorted(missing)}"
+        )
+
+
+class TestPromptAuditInvariant:
+    """Security rule 4 for prompts."""
+
+    def test_prompts_have_audit_logger_in_closure(self, all_components: dict[str, Any]) -> None:
+        prompt_fns = {k: v for k, v in all_components.items() if k.endswith("_prompt")}
+        missing = [name for name, fn in prompt_fns.items() if not _has_instance_of(fn, AuditLogger)]
+        assert not missing, (
+            f"{len(missing)} prompt(s) have no AuditLogger in closure — "
+            f"cannot enforce security rule 4 for prompts: {sorted(missing)}"
         )


### PR DESCRIPTION
Closes #136.

## What

Closes the security gap where `SecurityMiddleware.on_call_tool` fired for **tools only** — resources and prompts had no middleware coverage and no test asserting their enforcement.

### `src/comfyui_mcp/middleware.py`
- **`on_read_resource`** hook — rate-limit (`ResourceError` on exceed) + entry audit keyed by resource URI. Fires for every resource read.
- **`on_get_prompt`** hook — rate-limit (`PromptError` on exceed) + entry audit keyed by prompt name, with argument redaction. Fires for every prompt render.
- Both reuse the same `_limiter_for()` / `_redact_sensitive()` helpers as `on_call_tool`. Resources/prompts default to the `"read"` bucket via the `_TOOL_CATEGORIES` fallback.

### `tests/test_security_invariants.py`
- New `all_components` fixture registers resources and prompts.
- 4 new closure-invariant test classes: `TestResourceRateLimiterInvariant`, `TestResourceAuditInvariant`, `TestPromptRateLimiterInvariant`, `TestPromptAuditInvariant`. **Closes the test gap** — previously no test asserted resources/prompts had the security primitives in their closures.

### `tests/test_middleware_resource_prompt.py` (3 tests)
- `on_read_resource` writes an audit record on resource read
- `on_read_resource` enforces the rate limit (`ResourceError` on exceed)
- `on_get_prompt` writes an audit record on prompt render (via `render_prompt`, not `get_prompt` which only lists the definition)

## Verification

- [x] `uv run pytest` — **587 passed** (3 new middleware + 4 new invariants + 580 existing)
- [x] `uv run mypy src/comfyui_mcp/` — clean (35 source files)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run pre-commit run --all-files` — green

## Notes

- The in-tool `limiter.check()` + `audit.async_log(action="called")` calls in `resources.py`/`prompts.py` are now redundant (middleware covers them) but **kept in this PR** — #137 handles the in-tool removal with the spy-based invariant test (presence vs invocation) that proves the middleware actually fires.

## Do not

- No in-tool removal — that is #137.
- No DI/elicitation/tasks changes.

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>