### PR TITLE
Wire built-in FastMCP 4 middleware (caching, limiting, ping, logging) (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Migrated to FastMCP 4 beta** (`fastmcp[tasks]==4.0.0b1`, built on MCP SDK
-  v2). The server now imports `FastMCP` from `fastmcp` instead of the
-  `mcp.server.fastmcp` bundle bundled in `mcp` v1. `ToolAnnotations` field
-  arguments converted from camelCase to snake_case (`readOnlyHint` →
-  `read_only_hint`, etc.). `host`/`port` transport settings moved from the
-  `FastMCP()` constructor to `mcp.run()`; the streamable-HTTP transport is
-  now named `"http"` internally (#123, #129).
-- **Consolidated `CLAUDE.md` into `AGENTS.md`** — single harness-agnostic
-  entry point, no more Claude Code coupling. All live references in tests,
-  the review subagent, and rules updated (#123, #129).
-- **Updated `.opencode/rules/`** to permit the cleaner architecture the
-  migration unlocks: security rules 3/4 accept middleware enforcement as
-  an alternative to in-tool calls; architecture rule 11 accepts
-  module-level `Depends()`-decorated functions alongside the
-  `register_*_tools()` factory; tools.md checklist rewritten for dual
-  enforcement paths and DI; testing rule 19 covers both enforcement paths
-  (#123, #129).
-
 ### Added
 
+- **Built-in FastMCP 4 middleware wired** alongside `SecurityMiddleware` —
+  `ResponseCachingMiddleware` (caches read-only tools + the 4 `comfyui://`
+  resources, 30s TTL), `ResponseLimitingMiddleware` (caps
+  `list_nodes`/`list_models`/`get_history` payloads at 500KB),
+  `PingMiddleware` (keeps long-lived HTTP connections alive),
+  `StructuredLoggingMiddleware` (ops/observability, `include_payloads=False`)
+  (#139).
+- **`SecurityMiddleware` covers resources and prompts** — added
+  `on_read_resource` and `on_get_prompt` hooks so the middleware enforces
+  rate-limit + entry-audit for all three component types, not just tools.
+  Closes the gap where resources/prompts had no middleware coverage and no
+  test guardrail (#136).
 - **Resources** (`resources.py`) — read-only ComfyUI state the LLM can
   browse by URI without a tool call: `comfyui://models/{folder}`,
   `comfyui://nodes/installed`, `comfyui://queue`, `comfyui://system`.
@@ -46,8 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependency injection** (`dependencies.py`) — `Depends()` providers
   for the `client`/`audit`/`inspector`/`limiter` singletons
   (`configure_dependencies()` at startup). `tools/history_di.py` is the
-  proof module; the remaining tools migrate incrementally. Per-file
-  `B008` ruff ignore for the `Depends()`-in-default idiom (#126, #132).
+  canonical DI module — the factory `history.py` was deleted (#126, #132,
+  #138). Per-file `B008` ruff ignore for the `Depends()`-in-default idiom.
 - **Elicitation gate** — enforce-mode workflows with dangerous-node or
   suspicious-input warnings now `ctx.elicit()` the user for confirmation
   before submission. Decline/cancel raises `WorkflowBlockedError` without
@@ -58,6 +50,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tasks.enabled` config + `COMFYUI_TASKS_ENABLED`/
   `COMFYUI_TASKS_BACKEND_URL` env overrides. In-memory (`memory://`) or
   Redis (`redis://host:port/db`) backends (#128, #134).
+
+### Changed
+
+- **Dropped redundant in-tool limiter/audit boilerplate** — 43
+  `limiter.check()` and 22 `audit.async_log(action="called")` calls removed
+  from tool bodies now that `SecurityMiddleware` enforces them. The 41
+  lifecycle audit logs (`submitted`, `completed`, `inspected`, etc.) stay.
+  Invariant tests strengthened from closure-presence to
+  middleware-invocation (prove enforcement fires, not just capture) (#137).
+- **Migrated to FastMCP 4 beta** (`fastmcp[tasks]==4.0.0b1`, built on MCP SDK
+  v2). The server now imports `FastMCP` from `fastmcp` instead of the
+  `mcp.server.fastmcp` bundle bundled in `mcp` v1. `ToolAnnotations` field
+  arguments converted from camelCase to snake_case (`readOnlyHint` →
+  `read_only_hint`, etc.). `host`/`port` transport settings moved from the
+  `FastMCP()` constructor to `mcp.run()`; the streamable-HTTP transport is
+  now named `"http"` internally (#123, #129).
+- **Consolidated `CLAUDE.md` into `AGENTS.md`** — single harness-agnostic
+  entry point, no more Claude Code coupling. All live references in tests,
+  the review subagent, and rules updated (#123, #129).
+- **Updated `.opencode/rules/`** to permit the cleaner architecture the
+  migration unlocks: security rules 3/4 accept middleware enforcement as
+  an alternative to in-tool calls; architecture rule 11 accepts
+  module-level `Depends()`-decorated functions alongside the
+  `register_*_tools()` factory; tools.md checklist rewritten for dual
+  enforcement paths and DI; testing rule 19 covers both enforcement paths
+  (#123, #129).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Sensitive fields (`token`, `password`, `secret`, `api_key`, `authorization`) are
 - `SecurityMiddleware` centralizes rate-limit checks + entry audit logging across every tool call (FastMCP 4 `on_call_tool` hook), so the per-tool `limiter.check()` / `audit.async_log(action="called")` boilerplate can be dropped. Tools keep their domain-specific lifecycle audit logs (`submitted`, `completed`, etc.)
 - Sensitive tool arguments (`token`, `password`, `api_key`, ...) are redacted by the middleware before the entry audit record is written
 - `mask_error_details=True` on the server constructor masks internal exception tracebacks from clients — only `ToolError` messages (which we control) include details
+- Built-in FastMCP 4 middleware wired alongside `SecurityMiddleware` (see `build_middleware_stack()`): `ResponseCachingMiddleware` (caches read-only tools + the 4 `comfyui://` resources, 30s TTL), `ResponseLimitingMiddleware` (caps `list_nodes`/`list_models`/`get_history` payloads at 500KB), `PingMiddleware` (keeps long-lived HTTP connections alive), `StructuredLoggingMiddleware` (ops/observability, `include_payloads=False` — the AuditLogger already redacts).
 
 **HTTP Client** (`client.py`)
 - Configurable TLS verification, connect/read timeouts

--- a/src/comfyui_mcp/middleware.py
+++ b/src/comfyui_mcp/middleware.py
@@ -148,10 +148,52 @@ def build_middleware_stack(
 
     Order matters: the first added runs first on the way in, last on the way
     out. SecurityMiddleware runs early so rate limiting + audit apply to every
-    call before the tool body executes.
+    call before the tool body executes. The built-in middleware (#139) adds:
+    - ResponseCachingMiddleware: caches read-only tools + the 4 resources with
+      a short TTL so the bespoke _OBJECT_INFO_TTL cache in client.py can be
+      dropped once object_info-backed tools are covered.
+    - ResponseLimitingMiddleware: caps large list_nodes/list_models/get_history
+      payloads so they cannot blow an LLM context window.
+    - PingMiddleware: keeps long-lived HTTP connections alive (no-op on stdio).
+    - StructuredLoggingMiddleware: general request/response logging for ops,
+      distinct from the security AuditLogger. include_payloads=False to avoid
+      double-redaction work.
     """
+    from fastmcp.server.middleware import PingMiddleware
+    from fastmcp.server.middleware.caching import (
+        CallToolSettings,
+        ReadResourceSettings,
+        ResponseCachingMiddleware,
+    )
+    from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+    from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
+
     return [
         SecurityMiddleware(
             audit=audit, rate_limiters=rate_limiters, tool_categories=tool_categories
         ),
+        ResponseCachingMiddleware(
+            call_tool_settings=CallToolSettings(
+                included_tools=[
+                    "comfyui_list_nodes",
+                    "comfyui_get_node_info",
+                    "comfyui_list_model_folders",
+                    "comfyui_list_extensions",
+                    "comfyui_get_server_features",
+                ],
+                ttl=30,
+            ),
+            read_resource_settings=ReadResourceSettings(ttl=30),
+        ),
+        ResponseLimitingMiddleware(
+            max_size=500_000,
+            tools=[
+                "comfyui_list_nodes",
+                "comfyui_get_node_info",
+                "comfyui_list_models",
+                "comfyui_get_history",
+            ],
+        ),
+        PingMiddleware(interval_ms=30000),
+        StructuredLoggingMiddleware(include_payloads=False),
     ]

--- a/tests/test_builtin_middleware.py
+++ b/tests/test_builtin_middleware.py
@@ -1,0 +1,143 @@
+"""Tests for built-in FastMCP 4 middleware wired in #139.
+
+Verifies ResponseCachingMiddleware (cache hit skips the ComfyUI round-trip),
+ResponseLimitingMiddleware (large payloads truncated), PingMiddleware
+(present and does not break flows), and StructuredLoggingMiddleware (present).
+These complement the custom SecurityMiddleware (#125).
+"""
+
+from __future__ import annotations
+
+import httpx
+import respx
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.middleware import build_middleware_stack
+from comfyui_mcp.security.rate_limit import RateLimiter
+
+
+def _rate_limiters() -> dict[str, RateLimiter]:
+    return {
+        "read": RateLimiter(max_per_minute=600),
+        "workflow": RateLimiter(max_per_minute=600),
+        "generation": RateLimiter(max_per_minute=600),
+        "file": RateLimiter(max_per_minute=600),
+    }
+
+
+class TestBuildMiddlewareStackIncludesBuiltins:
+    def test_stack_includes_response_caching(self, tmp_path):
+        from fastmcp.server.middleware.caching import ResponseCachingMiddleware
+
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        stack = build_middleware_stack(
+            audit=audit, rate_limiters=_rate_limiters(), tool_categories={}
+        )
+        assert any(isinstance(m, ResponseCachingMiddleware) for m in stack), (
+            "ResponseCachingMiddleware not in the stack — read-only tools/resources "
+            "won't be cached, and the bespoke _OBJECT_INFO_TTL cache can't be dropped"
+        )
+
+    def test_stack_includes_response_limiting(self, tmp_path):
+        from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
+
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        stack = build_middleware_stack(
+            audit=audit, rate_limiters=_rate_limiters(), tool_categories={}
+        )
+        assert any(isinstance(m, ResponseLimitingMiddleware) for m in stack), (
+            "ResponseLimitingMiddleware not in the stack — large list_nodes/list_models/"
+            "get_history payloads can blow LLM context with no framework-level cap"
+        )
+
+    def test_stack_includes_ping(self, tmp_path):
+        from fastmcp.server.middleware import PingMiddleware
+
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        stack = build_middleware_stack(
+            audit=audit, rate_limiters=_rate_limiters(), tool_categories={}
+        )
+        assert any(isinstance(m, PingMiddleware) for m in stack)
+
+    def test_stack_includes_structured_logging(self, tmp_path):
+        from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+
+        audit = AuditLogger(audit_file=tmp_path / "audit.log")
+        stack = build_middleware_stack(
+            audit=audit, rate_limiters=_rate_limiters(), tool_categories={}
+        )
+        assert any(isinstance(m, StructuredLoggingMiddleware) for m in stack)
+
+
+class TestResponseCachingBehavior:
+    @respx.mock
+    async def test_cached_tool_skips_second_round_trip(self, tmp_path):
+        """A cached read-only tool does not hit the ComfyUI API on the second
+        call within the TTL — the bespoke _OBJECT_INFO_TTL cache is no longer
+        needed once this middleware covers the object_info-backed tools."""
+        from fastmcp.server.middleware.caching import ResponseCachingMiddleware
+
+        client = ComfyUIClient(base_url="http://test:8188")
+        AuditLogger(audit_file=tmp_path / "audit.log")
+        _rate_limiters()
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def comfyui_list_nodes(limit: int = 25, offset: int = 0) -> dict:
+            info = await client.get_object_info()
+            return {"items": sorted(info.keys())[offset : offset + limit], "total": len(info)}
+
+        mcp.add_middleware(
+            ResponseCachingMiddleware(
+                call_tool_settings={"included_tools": ["comfyui_list_nodes"], "ttl": 30}
+            )
+        )
+        route = respx.get("http://test:8188/object_info").mock(
+            return_value=httpx.Response(200, json={"KSampler": {}, "CLIPTextEncode": {}})
+        )
+        first = await mcp.call_tool("comfyui_list_nodes", {"limit": 25, "offset": 0})
+        assert first.is_error is False
+        assert route.calls.call_count == 1
+        # Second call within TTL — should be served from cache, no new HTTP call
+        second = await mcp.call_tool("comfyui_list_nodes", {"limit": 25, "offset": 0})
+        assert second.is_error is False
+        assert route.calls.call_count == 1, (
+            f"ResponseCachingMiddleware did not cache — second call hit the API "
+            f"(call count {route.calls.call_count})"
+        )
+
+
+class TestResponseLimitingBehavior:
+    async def test_large_response_truncated(self, tmp_path):
+        """A tool response exceeding max_size is truncated with the suffix."""
+        from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
+
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def big_tool() -> str:
+            return "x" * 10_000
+
+        mcp.add_middleware(ResponseLimitingMiddleware(max_size=500, tools=["big_tool"]))
+        result = await mcp.call_tool("big_tool", {})
+        text = result.content[0].text if result.content else ""
+        assert len(text) <= 600  # truncated + suffix
+        assert "truncated" in text.lower()
+
+
+class TestPingDoesNotBreakFlows:
+    async def test_ping_present_and_tool_call_succeeds(self, tmp_path):
+        """PingMiddleware is wired and does not break a normal tool call."""
+        from fastmcp.server.middleware import PingMiddleware
+
+        mcp = FastMCP("test")
+
+        @mcp.tool
+        async def simple_tool() -> dict:
+            return {"ok": True}
+
+        mcp.add_middleware(PingMiddleware(interval_ms=60000))
+        result = await mcp.call_tool("simple_tool", {})
+        assert result.is_error is False


### PR DESCRIPTION
Closes #139.

## What

Wires the FastMCP 4 built-in middleware alongside the custom `SecurityMiddleware` in `build_middleware_stack()`:

- **`ResponseCachingMiddleware`** — caches read-only tools (`list_nodes`, `get_node_info`, `list_model_folders`, `list_extensions`, `get_server_features`) + the 4 `comfyui://` resources, 30s TTL. Lets the bespoke `_OBJECT_INFO_TTL` cache in `client.py` be dropped once coverage is confirmed.
- **`ResponseLimitingMiddleware`** — caps `list_nodes`/`get_node_info`/`list_models`/`get_history` payloads at 500KB.
- **`PingMiddleware(interval_ms=30000)`** — keeps long-lived HTTP connections alive (no-op on stdio).
- **`StructuredLoggingMiddleware(include_payloads=False)`** — ops/observability logging, distinct from the security `AuditLogger`.

Order: `SecurityMiddleware` first (rate-limit + entry-audit gate), then caching, limiting, ping, logging.

## Tests (`tests/test_builtin_middleware.py`, 7 tests)
- `build_middleware_stack` includes all 4 built-ins
- `ResponseCachingMiddleware`: cached tool skips the ComfyUI round-trip on the second call within TTL (respx route called once)
- `ResponseLimitingMiddleware`: large response truncated with suffix
- `PingMiddleware`: present and a normal tool call still succeeds

## Docs
- README security-controls section + CHANGELOG Unreleased entry
- graphify-out refreshed (AST-only, free)

## Verification
- [x] `uv run pytest` — **591 passed** (7 new + 584 existing)
- [x] `uv run mypy` / `ruff` / `pre-commit` — green

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>