### PR TITLE
Use native /api/jobs/{id}/cancel + add batch cancel (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Native `/api/jobs/{id}/cancel` + batch cancel** — `comfyui_cancel_job`
+  now uses the native state-agnostic jobs-cancel endpoint (server classifies
+  running/pending/terminal) and falls back to the legacy `/queue` delete on
+  404 (older ComfyUI). New `comfyui_cancel_jobs` tool batch-cancels by
+  `job_ids` via `/api/jobs/cancel` (#141).
 - **`ctx.report_progress` + `ctx.read_resource` in generation tools** —
   `run_workflow_stream` reports step/total as MCP progress notifications
   (clients get live updates instead of polling `get_progress`); `generate_image`

--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | `comfyui_get_queue` | Get current execution queue state. |
 | `comfyui_list_jobs` | List jobs across queue + history with status filter, sorting, and pagination. |
 | `comfyui_get_job` | Look up a single job (queued/running/finished) by prompt_id. |
-| `comfyui_cancel_job` | Cancel a running or queued job. |
+| `comfyui_cancel_job` | Cancel a running or queued job. Uses the native `/api/jobs/{id}/cancel` endpoint and falls back to the legacy `/queue` delete on 404 (older ComfyUI builds). |
+| `comfyui_cancel_jobs` | Batch-cancel one or more jobs by prompt_id via `/api/jobs/cancel`. |
 | `comfyui_interrupt` | Interrupt the running workflow (global, or targeted via optional prompt_id). |
 | `comfyui_get_queue_status` | Get detailed queue status including running and pending prompts. |
 | `comfyui_clear_queue` | Clear pending and/or running items from the queue. |

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -249,6 +249,26 @@ class ComfyUIClient:
         _validate_prompt_id(prompt_id)
         await self._request("post", "/queue", json={"delete": [prompt_id]})
 
+    async def cancel_job_native(self, prompt_id: str) -> bool:
+        """POST /api/jobs/{id}/cancel — native state-agnostic single-job
+        cancel (#141). Returns True on success, False on 404 (older ComfyUI
+        builds that lack the jobs API — caller should fall back to the
+        legacy /queue delete). Raises on other errors.
+        """
+        _validate_prompt_id(prompt_id)
+        try:
+            await self._request("post", f"/api/jobs/{prompt_id}/cancel")
+            return True
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return False
+            raise
+
+    async def cancel_jobs_batch(self, job_ids: list[str]) -> dict:
+        """POST /api/jobs/cancel — batch cancel by job_ids (#141)."""
+        r = await self._request("post", "/api/jobs/cancel", json={"job_ids": job_ids})
+        return r.json()
+
     async def upload_image(
         self,
         data: bytes,

--- a/src/comfyui_mcp/server.py
+++ b/src/comfyui_mcp/server.py
@@ -123,6 +123,7 @@ _TOOL_CATEGORIES: dict[str, str] = {
     "get_custom_node_status": "read",
     # job tools — mutating queue ops use workflow, reads use read
     "cancel_job": "workflow",
+    "cancel_jobs": "workflow",
     "interrupt": "workflow",
     "clear_queue": "workflow",
     "get_queue": "read",

--- a/src/comfyui_mcp/tools/jobs.py
+++ b/src/comfyui_mcp/tools/jobs.py
@@ -128,11 +128,36 @@ def register_job_tools(
         )
     )
     async def comfyui_cancel_job(prompt_id: str) -> str:
-        """Cancel a running or queued job by its prompt_id."""
-        await client.delete_queue_item(prompt_id)
+        """Cancel a running or queued job by its prompt_id.
+
+        Uses the native /api/jobs/{id}/cancel endpoint (server classifies
+        running/pending/terminal) and falls back to the legacy /queue delete
+        on 404 (older ComfyUI builds).
+        """
+        cancelled = await client.cancel_job_native(prompt_id)
+        if not cancelled:
+            await client.delete_queue_item(prompt_id)
         return f"Cancelled job {prompt_id}"
 
     tool_fns["comfyui_cancel_job"] = comfyui_cancel_job
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            read_only_hint=False,
+            destructive_hint=True,
+            idempotent_hint=True,
+            open_world_hint=True,
+        )
+    )
+    async def comfyui_cancel_jobs(job_ids: list[str]) -> dict[str, Any]:
+        """Batch-cancel one or more jobs by their prompt_ids via /api/jobs/cancel.
+
+        Useful for "cancel all my queued jobs" without N round-trips.
+        """
+        result = await client.cancel_jobs_batch(job_ids)
+        return {"cancelled": len(job_ids), "job_ids": job_ids, "result": result}
+
+    tool_fns["comfyui_cancel_jobs"] = comfyui_cancel_jobs
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/tests/test_native_cancel.py
+++ b/tests/test_native_cancel.py
@@ -1,0 +1,80 @@
+"""Tests for native /api/jobs/{id}/cancel + batch cancel (#141).
+
+Verifies the native jobs-cancel endpoint is used with a fallback to the
+legacy /queue delete on 404 (older ComfyUI builds), and the new batch
+cancel tool works.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.tools.jobs import register_job_tools
+
+
+@pytest.fixture
+def components(tmp_path):
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    limiter = RateLimiter(max_per_minute=60)
+    return client, audit, limiter
+
+
+class TestCancelJobNative:
+    @respx.mock
+    async def test_uses_native_jobs_cancel_when_available(self, components):
+        """When /api/jobs/{id}/cancel returns 200, cancel_job uses it (not
+        the legacy /queue delete)."""
+        client, audit, limiter = components
+        native = respx.post(
+            "http://test:8188/api/jobs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/cancel"
+        ).mock(return_value=httpx.Response(200, json={"cancelled": True}))
+        legacy = respx.post("http://test:8188/queue").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        await tools["comfyui_cancel_job"](prompt_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        assert native.called
+        assert not legacy.called, "legacy /queue delete should not be called when native succeeds"
+
+    @respx.mock
+    async def test_falls_back_to_legacy_queue_delete_on_404(self, components):
+        """When /api/jobs/{id}/cancel returns 404 (older ComfyUI), cancel_job
+        falls back to the legacy /queue delete."""
+        client, audit, limiter = components
+        respx.post("http://test:8188/api/jobs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/cancel").mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
+        legacy = respx.post("http://test:8188/queue").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        await tools["comfyui_cancel_job"](prompt_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        assert legacy.called, "should fall back to legacy /queue delete on 404"
+
+
+class TestCancelJobsBatch:
+    @respx.mock
+    async def test_batch_cancel_posts_job_ids(self, components):
+        """comfyui_cancel_jobs (batch) POSTs job_ids to /api/jobs/cancel."""
+        client, audit, limiter = components
+        route = respx.post("http://test:8188/api/jobs/cancel").mock(
+            return_value=httpx.Response(200, json={"cancelled": 2})
+        )
+        mcp = FastMCP("test")
+        tools = register_job_tools(mcp, client, audit, limiter)
+        result = await tools["comfyui_cancel_jobs"](job_ids=["job-1", "job-2"])
+        assert route.called
+        import json
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["job_ids"] == ["job-1", "job-2"]
+        assert "cancelled" in str(result)

--- a/tests/test_tools_jobs.py
+++ b/tests/test_tools_jobs.py
@@ -47,6 +47,10 @@ class TestCancelJob:
     @respx.mock
     async def test_cancel_job_sends_delete(self, components):
         client, audit, limiter = components
+        # Native /api/jobs/{id}/cancel 404s (older ComfyUI) → fall back to /queue delete
+        respx.post("http://test:8188/api/jobs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/cancel").mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
         route = respx.post("http://test:8188/queue").mock(return_value=httpx.Response(200, json={}))
         mcp = FastMCP("test")
         tools = register_job_tools(mcp, client, audit, limiter)


### PR DESCRIPTION
Closes #141.

## What

`comfyui_cancel_job` now uses the native state-agnostic jobs-cancel endpoint (server classifies running/pending/terminal) and falls back to the legacy `/queue` delete on 404 (older ComfyUI). New `comfyui_cancel_jobs` tool batch-cancels by `job_ids` via `/api/jobs/cancel`.

### `client.py`
- `cancel_job_native(prompt_id)` — `POST /api/jobs/{id}/cancel`. Returns `True` on success, `False` on 404 (caller falls back). Raises on other errors.
- `cancel_jobs_batch(job_ids)` — `POST /api/jobs/cancel` with `{job_ids: [...]}`.

### `tools/jobs.py`
- `comfyui_cancel_job` — try native, fall back to `delete_queue_item` on `False`.
- `comfyui_cancel_jobs` (new) — batch cancel by `job_ids`.

### `server.py` `_TOOL_CATEGORIES`: add `cancel_jobs` → `workflow`.

## Tests (`tests/test_native_cancel.py`, 3 tests)
- native endpoint used when available (legacy `/queue` not called)
- fallback to legacy `/queue` delete on 404
- batch cancel POSTs `job_ids` to `/api/jobs/cancel`
- existing `test_cancel_job_sends_delete` updated to mock the native 404 so the fallback fires.

## Docs
- README Tools table + CHANGELOG. graphify-out refreshed.

## Verification
- [x] `uv run pytest` — **599 passed** (3 new + 596 existing)
- [x] `uv run mypy` / `ruff` / `pre-commit` — green

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>