### PR TITLE
Expose /experiment/models metadata + preview endpoints (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`/experiment/models` metadata + preview** —
+  `comfyui_list_models_detailed` lists models in a folder with file
+  metadata (`name`, `pathIndex`, `modified`, `created`, `size`) from
+  `/experiment/models/{folder}`; `comfyui_get_model_preview` fetches a
+  model's preview image via `/experiment/models/preview/...` (returns
+  base64 image data + mime type, or `{"available": false}` on 404) (#143).
 - **`/settings` read/write** — `comfyui_get_settings` reads ComfyUI server
   settings (sampler defaults, UI prefs, feature flags) from `GET /settings`;
   `comfyui_update_settings` merges new settings via `POST /settings`

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | Tool | Description |
 |------|-------------|
 | `comfyui_list_models` | List available models by folder (checkpoints, loras, vae, etc.). |
+| `comfyui_list_models_detailed` | List models in a folder with file metadata (name, `pathIndex`, `modified`, `created`, `size`) from `/experiment/models/{folder}`. Use this when you need the `pathIndex` for preview lookups. |
+| `comfyui_get_model_preview` | Fetch a model's preview image via `/experiment/models/preview/{folder}/{path_index}/{filename}`. Returns base64-encoded image data + mime type, or `{"available": false}` on 404. |
 | `comfyui_list_nodes` | List all available node types. |
 | `comfyui_get_node_info` | Get detailed info about a specific node type. |
 | `comfyui_list_workflows` | List saved workflow templates. |

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -391,6 +391,29 @@ class ComfyUIClient:
         r = await self._request("get", f"/view_metadata/{folder}", params={"filename": filename})
         return r.json()
 
+    async def get_models_detailed(self, folder: str) -> list:
+        """GET /experiment/models/{folder} — model list with file metadata
+        (name, pathIndex, modified, created, size) per file (#143).
+        """
+        _validate_path_segment(folder, label="folder")
+        r = await self._request("get", f"/experiment/models/{folder}")
+        return r.json()
+
+    async def get_model_preview(
+        self, folder: str, path_index: int, filename: str
+    ) -> httpx.Response:
+        """GET /experiment/models/preview/{folder}/{path_index}/{filename} —
+        fetch a model's preview image bytes (#143). Returns the raw response
+        so the caller can inspect the content-type and bytes; a 404 means no
+        preview exists for the model.
+        """
+        _validate_path_segment(folder, label="folder")
+        if not filename or "\x00" in filename or ".." in filename:
+            raise ValueError(f"filename is invalid: {filename!r}")
+        return await self._request(
+            "get", f"/experiment/models/preview/{folder}/{path_index}/{filename}"
+        )
+
     async def get_prompt_status(self) -> dict:
         r = await self._request("get", "/prompt")
         return r.json()

--- a/src/comfyui_mcp/server.py
+++ b/src/comfyui_mcp/server.py
@@ -133,6 +133,8 @@ _TOOL_CATEGORIES: dict[str, str] = {
     "get_progress": "read",
     # discovery / history / workflow tools all use read
     "list_models": "read",
+    "list_models_detailed": "read",
+    "get_model_preview": "read",
     "list_nodes": "read",
     "get_node_info": "read",
     "list_workflows": "read",

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated, Any
 
+import httpx
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -183,6 +184,90 @@ def register_discovery_tools(
         return paginate(models, offset, limit, default_limit=25, max_limit=100)
 
     tool_fns["comfyui_list_models"] = comfyui_list_models
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=True,
+        )
+    )
+    async def comfyui_list_models_detailed(
+        folder: str = "checkpoints",
+    ) -> dict[str, Any]:
+        """List models in a folder with file metadata (name, pathIndex, modified, created, size).
+
+        Uses the /experiment/models/{folder} endpoint (#143). Use this when you
+        need the pathIndex (for preview lookups) or file sizes; use
+        comfyui_list_models for a bare-name listing.
+
+        Args:
+            folder: Model folder type (checkpoints, loras, vae, etc.)
+        """
+        sanitizer.validate_path_segment(folder, label="folder")
+        await audit.async_log(
+            tool="list_models_detailed", action="called", extra={"folder": folder}
+        )
+        models = await client.get_models_detailed(folder)
+        return {"folder": folder, "models": models, "count": len(models)}
+
+    tool_fns["comfyui_list_models_detailed"] = comfyui_list_models_detailed
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=True,
+        )
+    )
+    async def comfyui_get_model_preview(
+        folder: Annotated[str, Field(description="Model folder (checkpoints, loras, etc.)")],
+        path_index: Annotated[
+            int, Field(description="pathIndex from comfyui_list_models_detailed", ge=0)
+        ],
+        filename: Annotated[str, Field(description="Model filename")],
+    ) -> dict[str, Any]:
+        """Fetch a model's preview image via /experiment/models/preview (\\#143).
+
+        Returns the preview as base64-encoded image data with a mime_type, or
+        {"available": false} when the model has no preview (404).
+
+        Args:
+            folder: Model folder type.
+            path_index: The pathIndex from comfyui_list_models_detailed.
+            filename: The model filename.
+        """
+        sanitizer.validate_path_segment(folder, label="folder")
+        if not filename or "\x00" in filename or ".." in filename:
+            raise ValueError(f"filename is invalid: {filename!r}")
+        await audit.async_log(
+            tool="get_model_preview",
+            action="called",
+            extra={"folder": folder, "path_index": path_index, "filename": filename},
+        )
+        import base64
+
+        try:
+            r = await client.get_model_preview(folder, path_index, filename)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {"available": False, "folder": folder, "filename": filename}
+            raise
+        content_type = r.headers.get("content-type", "application/octet-stream")
+        data = r.content
+        encoded = base64.b64encode(data).decode("ascii")
+        return {
+            "available": True,
+            "folder": folder,
+            "filename": filename,
+            "mime_type": content_type,
+            "size_bytes": len(data),
+            "data_base64": encoded,
+        }
+
+    tool_fns["comfyui_get_model_preview"] = comfyui_get_model_preview
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -1,0 +1,97 @@
+"""Tests for /experiment/models metadata + preview endpoints (#143)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+from comfyui_mcp.tools.settings import (
+    register_settings_tools,  # noqa: F401  (ensure module load order)
+)
+
+
+@pytest.fixture
+def components(tmp_path):
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    limiter = RateLimiter(max_per_minute=60)
+    sanitizer = PathSanitizer(allowed_extensions=[".safetensors", ".png"])
+    return client, audit, limiter, sanitizer
+
+
+class TestGetModelsWithMetadata:
+    @respx.mock
+    async def test_returns_enriched_listing(self, components):
+        from comfyui_mcp.tools.discovery import register_discovery_tools
+
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/experiment/models/checkpoints").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "name": "flux-dev.safetensors",
+                        "pathIndex": 0,
+                        "size": 11967221016,
+                        "modified": 1715000000,
+                    },
+                    {
+                        "name": "sd_xl.safetensors",
+                        "pathIndex": 1,
+                        "size": 6694700000,
+                        "modified": 1714000000,
+                    },
+                ],
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_list_models_detailed"](folder="checkpoints")
+        assert result["count"] == 2
+        names = [m["name"] for m in result["models"]]
+        assert "flux-dev.safetensors" in names
+        assert result["models"][0]["pathIndex"] == 0
+
+
+class TestGetModelPreview:
+    @respx.mock
+    async def test_returns_image_bytes(self, components):
+        from comfyui_mcp.tools.discovery import register_discovery_tools
+
+        client, audit, limiter, sanitizer = components
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        respx.get(
+            "http://test:8188/experiment/models/preview/checkpoints/0/flux-dev.safetensors"
+        ).mock(
+            return_value=httpx.Response(
+                200, content=png_bytes, headers={"content-type": "image/png"}
+            )
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_get_model_preview"](
+            folder="checkpoints", path_index=0, filename="flux-dev.safetensors"
+        )
+        assert result["mime_type"] == "image/png"
+        assert result["size_bytes"] == len(png_bytes)
+
+    @respx.mock
+    async def test_no_preview_returns_empty(self, components):
+        from comfyui_mcp.tools.discovery import register_discovery_tools
+
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/experiment/models/preview/checkpoints/0/none.safetensors").mock(
+            return_value=httpx.Response(404, content=b"")
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+        result = await tools["comfyui_get_model_preview"](
+            folder="checkpoints", path_index=0, filename="none.safetensors"
+        )
+        assert result["available"] is False


### PR DESCRIPTION
Closes #143.

## What

Adds model listing with file metadata (`pathIndex`, `modified`, `created`, `size`) and a model-preview fetch, so an agent can see a model's output before choosing it.

### `client.py`
- `get_models_detailed(folder)` — `GET /experiment/models/{folder}`
- `get_model_preview(folder, path_index, filename)` — `GET /experiment/models/preview/{folder}/{path_index}/{filename}` (raw response; 404 = no preview)

### `tools/discovery.py`
- `comfyui_list_models_detailed` (read-only) — enriched listing
- `comfyui_get_model_preview` (read-only) — base64 image data + mime type + size, or `{available: false}` on 404. Path-validated through the sanitizer.

### `server.py` `_TOOL_CATEGORIES`: `list_models_detailed`/`get_model_preview` → `read`

## Tests (`tests/test_model_metadata.py`, 3 tests)
- `list_models_detailed` returns enriched listing with `pathIndex`
- `get_model_preview` returns image bytes + mime type + size
- `get_model_preview` returns `{available: false}` on 404

## Docs
- README Tools table + CHANGELOG. graphify-out refreshed.

## Verification
- [x] `uv run pytest` — **605 passed** (3 new + 602 existing)
- [x] `uv run mypy` / `ruff` / `pre-commit` — green

Co-Authored-By: ollama-cloud/glm-5.2 <noreply@anthropic.com>