### PR TITLE
feat: expose /global_subgraphs endpoints + subgraph insertion (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`/global_subgraphs` endpoints** — `comfyui_list_subgraphs` lists
+  reusable subgraph templates (custom-node + blueprint subgraphs) from
+  `GET /global_subgraphs`; `comfyui_get_subgraph` fetches a single
+  subgraph's JSON (node map) from `GET /global_subgraphs/{id}` for
+  inspection or insertion. New `insert_subgraph` operation in
+  `workflow/operations.py` embeds a subgraph node map into a workflow,
+  with the inspector recursing into it (#110). Depends on the inspector
+  subgraph recursion from #110 (#144).
 - **Subgraph inspection** — the workflow inspector now recurses into
   subgraph nodes (class_type containing `subgraph`) when the nested node map
   is embedded inline, so dangerous nodes and suspicious inputs inside

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ docker run --rm ghcr.io/hybridindie/comfyui_mcp:latest --help
 | `comfyui_list_model_folders` | List available model folder types. |
 | `comfyui_get_model_metadata` | Get metadata for a specific model file. |
 | `comfyui_audit_dangerous_nodes` | Scan all installed nodes to identify potentially dangerous ones. |
+| `comfyui_list_subgraphs` | List available reusable subgraph templates from ComfyUI (`/global_subgraphs`). |
+| `comfyui_get_subgraph` | Fetch a single subgraph's JSON for inspection or insertion (`/global_subgraphs/{id}`). |
 | `comfyui_get_system_info` | Sanitized GPU VRAM, queue depth, and ComfyUI version (whitelist-filtered from `/system_stats`). |
 | `comfyui_get_settings` | Read ComfyUI server settings (sampler defaults, UI prefs, feature flags) from `GET /settings`. |
 | `comfyui_update_settings` | Merge new settings into the ComfyUI server config via `POST /settings` (audit-logged; mutating). |

--- a/src/comfyui_mcp/client.py
+++ b/src/comfyui_mcp/client.py
@@ -384,6 +384,28 @@ class ComfyUIClient:
         r = await self._request("get", "/models")
         return r.json()
 
+    async def get_global_subgraphs(self) -> dict:
+        """GET /global_subgraphs — list reusable subgraph templates (#144).
+
+        Returns a dict mapping subgraph entry IDs to SubgraphEntry objects
+        (without the ``data`` field). Use ``get_global_subgraph(id)`` to
+        fetch the actual graph JSON for a specific subgraph.
+        """
+        r = await self._request("get", "/global_subgraphs")
+        return r.json()
+
+    async def get_global_subgraph(self, subgraph_id: str) -> dict:
+        """GET /global_subgraphs/{id} — fetch a single subgraph's JSON (#144).
+
+        The ``data`` field in the response contains the subgraph's node map
+        as a JSON string. Raises ``httpx.HTTPStatusError`` on 404 if the
+        subgraph ID does not exist.
+        """
+        _validate_path_segment(subgraph_id, label="subgraph_id")
+        r = await self._request("get", f"/global_subgraphs/{subgraph_id}")
+        r.raise_for_status()
+        return r.json()
+
     async def get_view_metadata(self, folder: str, filename: str) -> dict:
         _validate_path_segment(folder, label="folder")
         if not filename or "\x00" in filename or ".." in filename:

--- a/src/comfyui_mcp/tools/discovery.py
+++ b/src/comfyui_mcp/tools/discovery.py
@@ -657,4 +657,69 @@ def register_discovery_tools(
 
     tool_fns["comfyui_get_prompting_guide"] = comfyui_get_prompting_guide
 
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=True,
+        )
+    )
+    async def comfyui_list_subgraphs() -> dict[str, Any]:
+        """List available reusable subgraph templates from ComfyUI (#144).
+
+        Subgraphs are packaged node groups that can be inserted into a
+        workflow as a single unit. Use ``comfyui_get_subgraph`` to fetch
+        the actual graph JSON for a specific subgraph.
+
+        Returns:
+            Dict with ``subgraphs`` (mapping of entry IDs to metadata) and
+            ``count``.
+        """
+        subgraphs = await client.get_global_subgraphs()
+        return {"subgraphs": subgraphs, "count": len(subgraphs)}
+
+    tool_fns["comfyui_list_subgraphs"] = comfyui_list_subgraphs
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+            open_world_hint=True,
+        )
+    )
+    async def comfyui_get_subgraph(
+        subgraph_id: Annotated[
+            str,
+            Field(
+                description="Subgraph entry ID from comfyui_list_subgraphs",
+                min_length=1,
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Fetch a single subgraph's JSON for inspection or insertion (#144).
+
+        The ``data`` field in the response contains the subgraph's node map
+        as a JSON string. The workflow inspector recurses into this node
+        map when a subgraph node is submitted in a workflow (#110).
+
+        Args:
+            subgraph_id: The entry ID from ``comfyui_list_subgraphs``.
+
+        Returns:
+            The subgraph metadata + ``data`` (node map JSON string), or
+            ``{"available": false}`` if the subgraph ID does not exist.
+        """
+        sanitizer.validate_path_segment(subgraph_id, label="subgraph_id")
+        try:
+            subgraph = await client.get_global_subgraph(subgraph_id)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {"available": False, "subgraph_id": subgraph_id}
+            raise
+        return subgraph
+
+    tool_fns["comfyui_get_subgraph"] = comfyui_get_subgraph
+
     return tool_fns

--- a/src/comfyui_mcp/workflow/operations.py
+++ b/src/comfyui_mcp/workflow/operations.py
@@ -106,6 +106,28 @@ def _apply_disconnect(workflow: dict[str, Any], op: dict[str, Any]) -> None:
     del inputs[input_name]
 
 
+def _apply_insert_subgraph(workflow: dict[str, Any], op: dict[str, Any]) -> None:
+    """Insert a subgraph node with an embedded node map (#144).
+
+    Adds a subgraph wrapper node (e.g. ``Reroute_subgraph``) whose ``inputs``
+    contains the nested node map under the ``subgraph`` key. The workflow
+    inspector recurses into this node map (#110).
+    """
+    class_type = op.get("class_type")
+    if not class_type:
+        raise ValueError("insert_subgraph requires 'class_type'")
+    subgraph_nodes = op.get("subgraph_nodes")
+    if not isinstance(subgraph_nodes, dict):
+        raise ValueError("insert_subgraph requires 'subgraph_nodes' (a dict)")
+    node_id = op.get("node_id") or _next_node_id(workflow)
+    if node_id in workflow:
+        raise ValueError(f"Node '{node_id}' already exists")
+    workflow[node_id] = {
+        "class_type": class_type,
+        "inputs": {"subgraph": subgraph_nodes},
+    }
+
+
 def apply_operations(workflow: dict[str, Any], operations: list[dict[str, Any]]) -> dict[str, Any]:
     """Apply a list of operations to a workflow. Returns a new workflow dict.
 
@@ -119,6 +141,7 @@ def apply_operations(workflow: dict[str, Any], operations: list[dict[str, Any]])
         "set_input": _apply_set_input,
         "connect": _apply_connect,
         "disconnect": _apply_disconnect,
+        "insert_subgraph": _apply_insert_subgraph,
     }
     for i, op in enumerate(operations):
         op_type = op.get("op")

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -7,9 +7,9 @@ from fastmcp import FastMCP
 
 from comfyui_mcp.audit import AuditLogger
 from comfyui_mcp.client import ComfyUIClient
-from comfyui_mcp.security.inspector import WorkflowInspector
+from comfyui_mcp.security.inspector import WorkflowBlockedError, WorkflowInspector
 from comfyui_mcp.security.rate_limit import RateLimiter
-from comfyui_mcp.security.sanitizer import PathSanitizer
+from comfyui_mcp.security.sanitizer import PathSanitizer, PathValidationError
 from comfyui_mcp.tools.discovery import register_discovery_tools
 from comfyui_mcp.workflow.operations import apply_operations
 
@@ -147,6 +147,17 @@ class TestGetSubgraphTool:
         result = await tools["comfyui_get_subgraph"](subgraph_id="nonexistent")
         assert result["available"] is False
 
+    @respx.mock
+    async def test_get_subgraph_rejects_path_traversal(self, components):
+        """Path-traversal attempts in subgraph_id must be rejected by the sanitizer."""
+        client, audit, limiter, sanitizer = components
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        for bad_id in ["../etc/passwd", "foo/bar", "foo\x00bar", "foo;rm -rf /"]:
+            with pytest.raises(PathValidationError):
+                await tools["comfyui_get_subgraph"](subgraph_id=bad_id)
+
 
 # ---------------------------------------------------------------------------
 # Workflow operations — insert_subgraph
@@ -201,6 +212,25 @@ class TestInsertSubgraphOperation:
                 [{"op": "insert_subgraph", "class_type": "Reroute_subgraph"}],
             )
 
+    def test_insert_subgraph_rejects_duplicate_node_id(self):
+        """Inserting a subgraph with an existing node_id must raise."""
+        workflow = {
+            "1": {"class_type": "KSampler", "inputs": {"cfg": 7.0}},
+        }
+        subgraph_nodes = {"10": {"class_type": "KSampler", "inputs": {}}}
+        with pytest.raises(ValueError, match="already exists"):
+            apply_operations(
+                workflow,
+                [
+                    {
+                        "op": "insert_subgraph",
+                        "class_type": "Reroute_subgraph",
+                        "subgraph_nodes": subgraph_nodes,
+                        "node_id": "1",
+                    },
+                ],
+            )
+
 
 # ---------------------------------------------------------------------------
 # Inspector integration — a subgraph inserted via operations must be scanned
@@ -236,3 +266,30 @@ class TestInsertedSubgraphInspection:
         assert any("Terminal" in w for w in result.warnings), (
             "Dangerous node inside an inserted subgraph was not flagged"
         )
+
+    def test_enforce_mode_blocks_dangerous_node_in_inserted_subgraph(self):
+        """In enforce mode, a dangerous node inside an inserted subgraph must
+        block the workflow (the #110 recursion fix + #144 insertion)."""
+        inspector = WorkflowInspector(
+            mode="enforce",
+            dangerous_nodes=["Terminal"],
+            allowed_nodes=["KSampler", "Reroute_subgraph"],
+        )
+        workflow = {
+            "1": {"class_type": "KSampler", "inputs": {"cfg": 7.0}},
+        }
+        subgraph_nodes = {
+            "10": {"class_type": "Terminal", "inputs": {}},
+        }
+        result_wf = apply_operations(
+            workflow,
+            [
+                {
+                    "op": "insert_subgraph",
+                    "class_type": "Reroute_subgraph",
+                    "subgraph_nodes": subgraph_nodes,
+                },
+            ],
+        )
+        with pytest.raises(WorkflowBlockedError, match="Terminal"):
+            inspector.inspect(result_wf)

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -1,0 +1,238 @@
+"""Tests for /global_subgraphs endpoints and subgraph insertion (#144)."""
+
+import httpx
+import pytest
+import respx
+from fastmcp import FastMCP
+
+from comfyui_mcp.audit import AuditLogger
+from comfyui_mcp.client import ComfyUIClient
+from comfyui_mcp.security.inspector import WorkflowInspector
+from comfyui_mcp.security.rate_limit import RateLimiter
+from comfyui_mcp.security.sanitizer import PathSanitizer
+from comfyui_mcp.tools.discovery import register_discovery_tools
+from comfyui_mcp.workflow.operations import apply_operations
+
+_ALLOWED_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp", ".safetensors"]
+
+
+@pytest.fixture
+def components(tmp_path):
+    client = ComfyUIClient(base_url="http://test:8188")
+    audit = AuditLogger(audit_file=tmp_path / "audit.log")
+    limiter = RateLimiter(max_per_minute=60)
+    sanitizer = PathSanitizer(allowed_extensions=_ALLOWED_EXTENSIONS)
+    return client, audit, limiter, sanitizer
+
+
+@pytest.fixture
+def client():
+    return ComfyUIClient(base_url="http://test-comfyui:8188")
+
+
+# Sample /global_subgraphs response (mirrors ComfyUI subgraph_manager.py shape)
+_SAMPLE_SUBGRAPHS = {
+    "abc123def456": {
+        "source": "custom_node",
+        "name": "txt2img_upscale_macro",
+        "info": {"node_pack": "custom_nodes.my_pack"},
+    },
+    "789xyz012abc": {
+        "source": "templates",
+        "name": "basic_txt2img",
+        "info": {"node_pack": "comfyui"},
+    },
+}
+
+_SAMPLE_SUBGRAPH_DATA = {
+    "source": "custom_node",
+    "name": "txt2img_upscale_macro",
+    "info": {"node_pack": "custom_nodes.my_pack"},
+    "data": (
+        '{"1": {"class_type": "KSampler", "inputs": {"cfg": 7.0}}, '
+        '"2": {"class_type": "SaveImage", "inputs": {}}}'
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Client methods
+# ---------------------------------------------------------------------------
+
+
+class TestClientSubgraphs:
+    @respx.mock
+    async def test_get_global_subgraphs(self, client):
+        respx.get("http://test-comfyui:8188/global_subgraphs").mock(
+            return_value=httpx.Response(200, json=_SAMPLE_SUBGRAPHS)
+        )
+        result = await client.get_global_subgraphs()
+        assert "abc123def456" in result
+        assert result["abc123def456"]["name"] == "txt2img_upscale_macro"
+
+    @respx.mock
+    async def test_get_global_subgraph_single(self, client):
+        respx.get("http://test-comfyui:8188/global_subgraphs/abc123def456").mock(
+            return_value=httpx.Response(200, json=_SAMPLE_SUBGRAPH_DATA)
+        )
+        result = await client.get_global_subgraph("abc123def456")
+        assert result["name"] == "txt2img_upscale_macro"
+        assert "data" in result
+
+    @respx.mock
+    async def test_get_global_subgraph_not_found(self, client):
+        respx.get("http://test-comfyui:8188/global_subgraphs/nonexistent").mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_global_subgraph("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Discovery tools
+# ---------------------------------------------------------------------------
+
+
+class TestListSubgraphsTool:
+    @respx.mock
+    async def test_list_subgraphs_returns_dict(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/global_subgraphs").mock(
+            return_value=httpx.Response(200, json=_SAMPLE_SUBGRAPHS)
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_list_subgraphs"]()
+        assert "abc123def456" in result["subgraphs"]
+        assert result["count"] == 2
+
+    @respx.mock
+    async def test_list_subgraphs_empty(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/global_subgraphs").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_list_subgraphs"]()
+        assert result["subgraphs"] == {}
+        assert result["count"] == 0
+
+
+class TestGetSubgraphTool:
+    @respx.mock
+    async def test_get_subgraph_returns_data(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/global_subgraphs/abc123def456").mock(
+            return_value=httpx.Response(200, json=_SAMPLE_SUBGRAPH_DATA)
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_get_subgraph"](subgraph_id="abc123def456")
+        assert result["name"] == "txt2img_upscale_macro"
+        assert "data" in result
+
+    @respx.mock
+    async def test_get_subgraph_not_found(self, components):
+        client, audit, limiter, sanitizer = components
+        respx.get("http://test:8188/global_subgraphs/nonexistent").mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
+        mcp = FastMCP("test")
+        tools = register_discovery_tools(mcp, client, audit, limiter, sanitizer)
+
+        result = await tools["comfyui_get_subgraph"](subgraph_id="nonexistent")
+        assert result["available"] is False
+
+
+# ---------------------------------------------------------------------------
+# Workflow operations — insert_subgraph
+# ---------------------------------------------------------------------------
+
+
+class TestInsertSubgraphOperation:
+    def test_insert_subgraph_adds_subgraph_node(self):
+        workflow = {
+            "1": {"class_type": "KSampler", "inputs": {"cfg": 7.0}},
+        }
+        subgraph_nodes = {
+            "10": {"class_type": "KSampler", "inputs": {"cfg": 8.0}},
+            "11": {"class_type": "SaveImage", "inputs": {}},
+        }
+        result = apply_operations(
+            workflow,
+            [
+                {
+                    "op": "insert_subgraph",
+                    "class_type": "Reroute_subgraph",
+                    "subgraph_nodes": subgraph_nodes,
+                },
+            ],
+        )
+        assert "2" in result
+        assert result["2"]["class_type"] == "Reroute_subgraph"
+        assert result["2"]["inputs"]["subgraph"] == subgraph_nodes
+
+    def test_insert_subgraph_with_custom_node_id(self):
+        workflow = {}
+        subgraph_nodes = {"10": {"class_type": "KSampler", "inputs": {}}}
+        result = apply_operations(
+            workflow,
+            [
+                {
+                    "op": "insert_subgraph",
+                    "class_type": "Reroute_subgraph",
+                    "subgraph_nodes": subgraph_nodes,
+                    "node_id": "99",
+                },
+            ],
+        )
+        assert "99" in result
+        assert result["99"]["class_type"] == "Reroute_subgraph"
+
+    def test_insert_subgraph_requires_subgraph_nodes(self):
+        workflow = {}
+        with pytest.raises(ValueError, match="subgraph_nodes"):
+            apply_operations(
+                workflow,
+                [{"op": "insert_subgraph", "class_type": "Reroute_subgraph"}],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Inspector integration — a subgraph inserted via operations must be scanned
+# ---------------------------------------------------------------------------
+
+
+class TestInsertedSubgraphInspection:
+    def test_inspector_flags_dangerous_node_in_inserted_subgraph(self):
+        """When a subgraph with a dangerous node is inserted into a workflow,
+        the inspector must flag it (the #110 recursion fix)."""
+        inspector = WorkflowInspector(
+            mode="audit",
+            dangerous_nodes=["Terminal"],
+            allowed_nodes=[],
+        )
+        workflow = {
+            "1": {"class_type": "KSampler", "inputs": {"cfg": 7.0}},
+        }
+        subgraph_nodes = {
+            "10": {"class_type": "Terminal", "inputs": {}},
+        }
+        result_wf = apply_operations(
+            workflow,
+            [
+                {
+                    "op": "insert_subgraph",
+                    "class_type": "Reroute_subgraph",
+                    "subgraph_nodes": subgraph_nodes,
+                },
+            ],
+        )
+        result = inspector.inspect(result_wf)
+        assert any("Terminal" in w for w in result.warnings), (
+            "Dangerous node inside an inserted subgraph was not flagged"
+        )


### PR DESCRIPTION
## Summary

Add ComfyUI subgraph discovery and composition — `comfyui_list_subgraphs`, `comfyui_get_subgraph` tools + `insert_subgraph` workflow operation.

## Problem (#144)

ComfyUI exposes reusable subgraph templates we didn't proxy:
- `GET /global_subgraphs` — list reusable subgraph templates
- `GET /global_subgraphs/{id}` — fetch a single subgraph's JSON (node map)

This was **blocked on #110** (inspector subgraph recursion), which merged in #154. The inspector now recurses into subgraph node maps, so it's safe to expose subgraph insertion — dangerous nodes inside an inserted subgraph are flagged.

## Changes

**Client** (`client.py`):
- `get_global_subgraphs()` — `GET /global_subgraphs`
- `get_global_subgraph(id)` — `GET /global_subgraphs/{id}` (with `raise_for_status` for 404 handling)

**Tools** (`discovery.py`):
- `comfyui_list_subgraphs` — read-only, lists available subgraph templates with entry IDs + metadata
- `comfyui_get_subgraph` — read-only, fetches a single subgraph's JSON; returns `{"available": false}` on 404. Path-segment sanitized.

**Workflow operations** (`operations.py`):
- `insert_subgraph` op — embeds a subgraph node map into a workflow as a subgraph wrapper node (`class_type` + `subgraph_nodes` under `inputs.subgraph`). The inspector recurses into this node map (#110), so dangerous nodes inside an inserted subgraph are flagged in audit mode and blocked in enforce mode.

## Tests (`test_subgraphs.py` — 11 tests)

- Client: `get_global_subgraphs`, `get_global_subgraph` (single + 404)
- Tools: `comfyui_list_subgraphs` (results + empty), `comfyui_get_subgraph` (data + not found)
- Operations: `insert_subgraph` (basic, custom node_id, validation)
- Inspector integration: dangerous node in inserted subgraph is flagged

## Verification

- [x] Subgraph list and single-subgraph fetch work
- [x] The workflow inspector recurses into inserted subgraph node inputs (#110 fix)
- [x] A dangerous node inside an inserted subgraph is flagged in enforce mode
- [x] 626 tests pass; mypy/ruff/pre-commit clean

## Checklist

- [x] Issue referenced (`closes #144`)
- [x] Red test written before the fix (11 failing to 11 passing)
- [x] Preflight clean (626 tests, ruff, mypy, format, pre-commit)
- [x] README updated (Tools table)
- [x] CHANGELOG updated

Closes #144